### PR TITLE
Log git commit info on robot init

### DIFF
--- a/robot.py
+++ b/robot.py
@@ -13,6 +13,10 @@ from components.vision import Vision
 
 from controllers.shooter import ShooterController
 
+from utilities import git
+
+GIT_INFO = git.describe()
+
 
 class MyRobot(magicbot.MagicRobot):
     shooter_control: ShooterController
@@ -26,7 +30,7 @@ class MyRobot(magicbot.MagicRobot):
     vision: Vision
 
     def createObjects(self) -> None:
-        pass
+        self.logger.info("pyrapidreact %s", GIT_INFO)
 
     def autonomousInit(self) -> None:
         pass

--- a/utilities/git.py
+++ b/utilities/git.py
@@ -6,6 +6,7 @@ def describe() -> str:
     robot_dir = pathlib.Path(__file__).parents[1]
     # would use a hidden file here, but deploy skips dotfiles
     fname = robot_dir / "gitid"
+
     if (robot_dir / ".git").is_dir():
         commit_hash = subprocess.check_output(
             ("git", "describe", "--broken", "--always", "--tags"), text=True
@@ -14,8 +15,18 @@ def describe() -> str:
             ("git", "branch", "--show-current"), text=True
         ).strip()
         desc = f"{commit_hash} ({branch})" if branch else commit_hash
-        with open(fname, "w") as f:
-            f.write(desc)
+
+        try:
+            with open(fname, "r") as f:
+                needs_write = f.read() != desc
+        except FileNotFoundError:
+            needs_write = True
+
+        if needs_write:
+            with open(fname, "w") as f:
+                f.write(desc)
+
         return desc
+
     with open(fname) as f:
         return f.read()

--- a/utilities/git.py
+++ b/utilities/git.py
@@ -1,0 +1,21 @@
+import pathlib
+import subprocess
+
+
+def describe() -> str:
+    robot_dir = pathlib.Path(__file__).parents[1]
+    # would use a hidden file here, but deploy skips dotfiles
+    fname = robot_dir / "gitid"
+    if (robot_dir / ".git").is_dir():
+        commit_hash = subprocess.check_output(
+            ("git", "describe", "--broken", "--always", "--tags"), text=True
+        ).strip()
+        branch = subprocess.check_output(
+            ("git", "branch", "--show-current"), text=True
+        ).strip()
+        desc = f"{commit_hash} ({branch})" if branch else commit_hash
+        with open(fname, "w") as f:
+            f.write(desc)
+        return desc
+    with open(fname) as f:
+        return f.read()


### PR DESCRIPTION
This is mostly a copy-paste from last year, with the following changes:

- Use `git branch --show-current` to get the current branch name, and support detached HEAD.
- Avoid writing the file if it hasn't changed.