### PR TITLE
pre-commit: Add autoflake

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,11 @@ repos:
       - id: check-toml
       - id: check-added-large-files
 
+  - repo: https://github.com/myint/autoflake
+    rev: v1.4
+    hooks:
+      - id: autoflake
+
   - repo: https://github.com/psf/black
     rev: 21.12b0
     hooks:


### PR DESCRIPTION
This adds [autoflake](https://github.com/myint/autoflake), an autofixer for unused imports and variables, to the pre-commit config.