### PR TITLE
pre-commit: Run autoflake with --in-place

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     rev: v1.4
     hooks:
       - id: autoflake
+        args: ['--in-place']
 
   - repo: https://github.com/psf/black
     rev: 21.12b0


### PR DESCRIPTION
https://github.com/thedropbears/vision-2022/pull/11 showed that the `autoflake` pre-commit hook needs to be run with `--in-place`, as this is not a default.