### PR TITLE
scalers: scale_value: Remove exponent parameter

### DIFF
--- a/utilities/scalers.py
+++ b/utilities/scalers.py
@@ -36,15 +36,13 @@ def scale_value(
     input_upper: float,
     output_lower: float,
     output_upper: float,
-    exponent: float = 1,
 ) -> float:
     """Scales a value based on the input range and output range.
     For example, to scale a joystick throttle (1 to -1) to 0-1, we would:
         scale_value(joystick.getThrottle(), 1, -1, 0, 1)
-    The output is then raised to the exponent argument.
     """
     input_distance = input_upper - input_lower
     output_distance = output_upper - output_lower
     ratio = (value - input_lower) / input_distance
     result = ratio * output_distance + output_lower
-    return math.copysign(result**exponent, result)
+    return result


### PR DESCRIPTION
This parameter is unused and untested.

This was removed in last year's robot code, as an obviously correct test was written and the code was shown to fail: https://github.com/thedropbears/pyinfiniterecharge/pull/141