### PR TITLE
Bump dependencies for roboRIO v4 image

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,14 +5,14 @@ name = "pypi"
 
 [packages]
 pyfrc = "~=2022.0.2"
-robotpy-halsim-gui = "~=2022.2.1"
+robotpy-halsim-gui = "~=2022.3.1"
 numpy = "~=1.22.1"
-robotpy-ctre = "~=2022.0.5"
-robotpy-navx = "~=2022.0.0"
-robotpy-rev = "~=2022.0.0"
+robotpy-ctre = "~=2022.1.0"
+robotpy-navx = "~=2022.0.1"
+robotpy-rev = "~=2022.0.1"
 robotpy-wpilib-utilities = "~=2022.0.1"
-robotpy-wpimath = "~=2022.2.1"
-wpilib = "~=2022.2.1"
+robotpy-wpimath = "~=2022.3.1"
+wpilib = "~=2022.3.1"
 
 [dev-packages]
 hypothesis = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bc35977f6e9ba0fbff06dc52adb766a31abf511fc2fe60e4bf98d5bafc38ddae"
+            "sha256": "d9046446e6252d56c656876bc764a986842c4365b63b6e557802b2f298ef8649"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -138,31 +138,28 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:0d245a2bf79188d3f361137608c3cd12ed79076badd743dc660750a9f3074f7c",
-                "sha256:26b4018a19d2ad9606ce9089f3d52206a41b23de5dfe8dc947d2ec49ce45d015",
-                "sha256:2db01d9838a497ba2aa9a87515aeaf458f42351d72d4e7f3b8ddbd1eba9479f2",
-                "sha256:3d62d6b0870b53799204515145935608cdeb4cebb95a26800b6750e48884cc5b",
-                "sha256:45a7dfbf9ed8d68fd39763940591db7637cf8817c5bce1a44f7b56c97cbe211e",
-                "sha256:4ac4d7c9f8ea2a79d721ebfcce81705fc3cd61a10b731354f1049eb8c99521e8",
-                "sha256:60f19c61b589d44fbbab8ff126640ae712e163299c2dd422bfe4edc7ec51aa9b",
-                "sha256:632e062569b0fe05654b15ef0e91a53c0a95d08ffe698b66f6ba0f927ad267c2",
-                "sha256:65f5e257987601fdfc63f1d02fca4d1c44a2b85b802f03bd6abc2b0b14648dd2",
-                "sha256:69958735d5e01f7b38226a6c6e7187d72b7e4d42b6b496aca5860b611ca0c193",
-                "sha256:78bfbdf809fc236490e7e65715bbd98377b122f329457fffde206299e163e7f3",
-                "sha256:7e957ca8112c689b728037cea9c9567c27cf912741fabda9efc2c7d33d29dfa1",
-                "sha256:800dfeaffb2219d49377da1371d710d7952c9533b57f3d51b15e61c4269a1b5b",
-                "sha256:831f2df87bd3afdfc77829bc94bd997a7c212663889d56518359c827d7113b1f",
-                "sha256:88d54b7b516f0ca38a69590557814de2dd638d7d4ed04864826acaac5ebb8f01",
-                "sha256:8d1563060e77096367952fb44fca595f2b2f477156de389ce7c0ade3aef29e21",
-                "sha256:b5ec9a5eaf391761c61fd873363ef3560a3614e9b4ead17347e4deda4358bca4",
-                "sha256:bcd19dab43b852b03868796f533b5f5561e6c0e3048415e675bec8d2e9d286c1",
-                "sha256:c51124df17f012c3b757380782ae46eee85213a3215e51477e559739f57d9bf6",
-                "sha256:e348ccf5bc5235fc405ab19d53bec215bb373300e5523c7b476cc0da8a5e9973",
-                "sha256:e60ef82c358ded965fdd3132b5738eade055f48067ac8a5a8ac75acc00cad31f",
-                "sha256:f8ad59e6e341f38266f1549c7c2ec70ea0e3d1effb62a44e5c3dba41c55f0187"
+                "sha256:03ae5850619abb34a879d5f2d4bb4dcd025d6d8fb72f5e461dae84edccfe129f",
+                "sha256:076aee5a3763d41da6bef9565fdf3cb987606f567cd8b104aded2b38b7b47abf",
+                "sha256:0b536b6840e84c1c6a410f3a5aa727821e6108f3454d81a5cd5900999ef04f89",
+                "sha256:15efb7b93806d438e3bc590ca8ef2f953b0ce4f86f337ef4559d31ec6cf9d7dd",
+                "sha256:168259b1b184aa83a514f307352c25c56af111c269ffc109d9704e81f72e764b",
+                "sha256:2638389562bda1635b564490d76713695ff497242a83d9b684d27bb4a6cc9d7a",
+                "sha256:3556c5550de40027d3121ebbb170f61bbe19eb639c7ad0c7b482cd9b560cd23b",
+                "sha256:4a176959b6e7e00b5a0d6f549a479f869829bfd8150282c590deee6d099bbb6e",
+                "sha256:515a8b6edbb904594685da6e176ac9fbea8f73a5ebae947281de6613e27f1956",
+                "sha256:55535c7c2f61e2b2fc817c5cbe1af7cb907c7f011e46ae0a52caa4be1f19afe2",
+                "sha256:59153979d60f5bfe9e4c00e401e24dfe0469ef8da6d68247439d3278f30a180f",
+                "sha256:60cb8e5933193a3cc2912ee29ca331e9c15b2da034f76159b7abc520b3d1233a",
+                "sha256:6767ad399e9327bfdbaa40871be4254d1995f4a3ca3806127f10cec778bd9896",
+                "sha256:76a4f9bce0278becc2da7da3b8ef854bed41a991f4226911a24a9711baad672c",
+                "sha256:8cf33634b60c9cef346663a222d9841d3bbbc0a2f00221d6bcfd0d993d5543f6",
+                "sha256:94dd11d9f13ea1be17bac39c1942f527cbf7065f94953cf62dfe805653da2f8f",
+                "sha256:aafa46b5a39a27aca566198d3312fb3bde95ce9677085efd02c86f7ef6be4ec7",
+                "sha256:badca914580eb46385e7f7e4e426fea6de0a37b9e06bec252e481ae7ec287082",
+                "sha256:d76a26c5118c4d96e264acc9e3242d72e1a2b92e739807b3b69d8d47684b6677"
             ],
             "index": "pypi",
-            "version": "==1.22.1"
+            "version": "==1.22.2"
         },
         "packaging": {
             "hashes": [
@@ -250,25 +247,25 @@
         },
         "pyntcore": {
             "hashes": [
-                "sha256:0bb860923027c8ef3b1e7d63599159d1c8b1bba5d33a7d2b2386034002f3d66a",
-                "sha256:0f56a6ed3d46b3568360fcfb6abb0625be8c4946ca59fb5971641a4fc3efcdd2",
-                "sha256:14a041f0018b8e2c8a852770bbfac354c8ef912f7b44a4bea262d9551c227427",
-                "sha256:43be18f7aca07b8ae9aae4a13ad182e782670d38494ad20fe5843f2cd5c472f3",
-                "sha256:4f7568e886ba5c0fd5e3e1ae2999bd005f0b5fff6b7cfbfbd9dbbdfe1a4a69c6",
-                "sha256:54c2e7f6bc49b8f5fb179be76f8ba751d32158ebabbe301a7b7d06450d75fb9c",
-                "sha256:5a1df1c49d2a08b77ef95b6e5b7f26ba991cda024beb6cb640762e52c8bf3b6f",
-                "sha256:75ca2f6491a5dc55923ed2a477242eb49a2a33ed8f7795111ffa13375f3b4bf5",
-                "sha256:7b6c784f8c4d90982303ce698aa67dae6f9eb78d957ee1ebc95c370360816074",
-                "sha256:8e84125d98da75dc1981279fe6ce32c87ce433747886e78e04625e91a740107a",
-                "sha256:99ec3659ec587cca94b11795652ca36e3239d45f2fd19a7f6fa450cd8bdde92c",
-                "sha256:ab056bdbe7c0d2286762e92d34d9a7e098bba34c7beb10dae7c93afa8fa1af3b",
-                "sha256:acf93bc15a08adacdf55348836f28cfb27927048a16a2abf2d5e03a25449c527",
-                "sha256:e5af5836d78ee9c75c3084202ca538701621bef88be7aa377cb82dafc340b5c6",
-                "sha256:ecb95f261db5542ae5109287e7a9e00cb466287b9b9cb3d32c24fbea1c887fbc",
-                "sha256:fae5d51263143620361058a1160ac1803d206b75a02ced2ed2cdd31bbf611181"
+                "sha256:14cb55f479d0fd21d0dce0773c3ba0601c3e0656ec8e66f2a2a1c0046989d088",
+                "sha256:169d1be1dca321f8d55bf561d4aa2b6bb92bc531f1337ce419b3e3f7aa4cf752",
+                "sha256:31e390e2ede8b1578b8edd0e7a295c24784c8fc6e38f7ecf442b5cbd9465a6d3",
+                "sha256:3b5eaca022057a18b50832d0c178f0dfb4b36b6a88bf8c0d45ba73f4c143b480",
+                "sha256:3ee39280c90b275cf5cacc32944b53df659d31d8e643940774475ba3aeb0d2f7",
+                "sha256:3fb8970bb02a7b4f888ed0abba4beacebdf752867d21e2b8200d511a2dbf5d95",
+                "sha256:4755292953a6a0b8f2d162a916c3352ed4e68862353c0e8ce8a12927dc589ad8",
+                "sha256:4dcc798d4b894b7fb0367272c0152ef4539b05ec8d9b9cd08835f9a1bb72c7e5",
+                "sha256:7afe9f5fe4a22b59a99bfe1490e3a53e68bfaf6c256c550b5702584380007be4",
+                "sha256:818357a9cf59a2c039f718516b9a20cbbf6f3a6dedd4b4b9e48e9df4b36a9526",
+                "sha256:8324a9c0d81b89ac358cbbfc02a4a1c2c45162d74c40d3f0353f84b1026e474b",
+                "sha256:94221f6c222dff45cd5aca5588c927d1b915a9dbc1306f0078592eb43526d924",
+                "sha256:9581b8973c585ebe4c50de28b2473eea213e0a1f23b19907dd833e1d6c0777ff",
+                "sha256:b1b3760bc7c8869e65d2716d4a697ba23f86f02f504140d68789cb002b22d7a6",
+                "sha256:b4137d273409b7a55b50a70181ca5ffc0058792a46e4492411340c300da73577",
+                "sha256:fd745d73ac887aef2fe65ac129c7e359cd232fb2a812fbeb8338b47291b7308f"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.2.1.2"
+            "version": "==2022.3.1.0"
         },
         "pyparsing": {
             "hashes": [
@@ -280,85 +277,85 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
-                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+                "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9",
+                "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==6.2.5"
+            "version": "==7.0.0"
         },
         "robotpy-ctre": {
             "hashes": [
-                "sha256:346fefe199f9eec276bbb131ed40eff56d2f01e3ad629f933896bd1d3552be09",
-                "sha256:40dc070f8c66d85337cfe4c342e12fdd8ebf565a2c059e20713cbe02c17431d1",
-                "sha256:59da36714d8890e1fcdeba7e52a00c0419d793b3ceb92be1195e74c31dd87e80",
-                "sha256:6c247ba997bfe268f5103c8293b9b78667696448d6fe18863626b027e1ed91b7",
-                "sha256:86161fa9145b4664d749f2e057b06b5d4b9c26c4e0153aa0d62f90f3e6d34e34",
-                "sha256:902edd986652cfa1ca271c4baf71112fe3808764e2db02ed7ec3c0ea4ec12a68",
-                "sha256:9a06a8c26091e77f858984fe878c023ad1bcf91d3ce58a6f9b863ea788dc61f6",
-                "sha256:a219743684e201e4827e24f981857aa7756e2ad2e592eed553cbf8618fcd9a9d",
-                "sha256:a5aca4f817b527192ad68a07ece187bcbbf8b3f1dd7821b39227d034563df4bb",
-                "sha256:b663f0432b137ef0cc90b4b2a32534a60850013d8026117b4aeba42d5c939790",
-                "sha256:bc3c78a732e66d8f3222396bb73ea053e2191b2b30941de72442c35acf244fe8",
-                "sha256:be2e28b5735afd2ae2a08cfdf2df33cbd2129bc8c298cac82fd03e2f65f174d0",
-                "sha256:d0b81264c5be4e60fe3299992b97d47ecaee95d20f955580bed8625a088d1325",
-                "sha256:e266f794f00f26921e15be24a83e67a95186cb16685749099aaadba21106fea1",
-                "sha256:e417af2730e47348b1512e3c02b020c0ca826d6900acee5ef8a911d4e4ebc397",
-                "sha256:fcf7bce810ce74ca8e9d4b4eeeabac9f8acd2eb8e21815d175760012aa4ffc47"
+                "sha256:3af78d48086af90bd16a7f11b5204d72c0b4351c059dff41f98635f2e2f00faf",
+                "sha256:4635dd126cfd7385abef5ee7c88774652b9c4fb213f2325b59016c571b4ad437",
+                "sha256:50dfacbd6c771d3f65ce5d3a07045a3cad9c3e28f13d4d7641ea4973ca48aae1",
+                "sha256:5459f8e6b1cab16420eb39948fd832a38685266e750b8e2f6e9774849549a14d",
+                "sha256:5fcf19839aa69cff0a9d5fbc3a8cb595be9040e0c4d29df2b5ef8abeb852957d",
+                "sha256:626cfd9b1a913a885584e902649e142e8c86d1a15453dca5c87f8bcd6d49e437",
+                "sha256:6fb2bf5ce4acc8c9b070510caa46ad95fbdef977a8a5b600d68e0f422e6cad47",
+                "sha256:7aedde0504a6ad96e55d83d02326bdcf1c1e6d3a91f14b4fd5e6e19348f38197",
+                "sha256:8bde2652e1fe69139912fce7006110e9252f94ce645dbf6eeb78690377301d74",
+                "sha256:a5eaa3fd8fd2d1b7b94252ab474321c986336bbc93c4510dab728f53cb04f254",
+                "sha256:ad46a89e749e0ac56b39edfee9a9e7eed051545e6692133ade5915480f18a606",
+                "sha256:b13ed9de72b48d6f19e1f465477ecb68f8fd2137592d7f246726942a6b746e18",
+                "sha256:b67615fba27f114ab7ac21f565e3c9c7ee5bf9168ac723e0355a55986bb2cb2e",
+                "sha256:b7a1bdc048ae243a377b29614785a28a2ff86c75fe65addf02f8637137c4466d",
+                "sha256:fe496783d804e4a7a768cd7eeb08c5d0d2a146b075ad209374a295f81f46d077",
+                "sha256:ffb3abd4e36e80b52adb9daaa46e40005c3d3fb9bfafdb8335f47de599dff71f"
             ],
             "index": "pypi",
-            "version": "==2022.0.5"
+            "version": "==2022.1.0"
         },
         "robotpy-hal": {
             "hashes": [
-                "sha256:29ec80e6d31348bad981c678ace34cedd9e78245fedd29cef707ad346d6c1f9c",
-                "sha256:3845a3087e571d0cafc25a54846896fd917e22757705022b151eba417e50d25e",
-                "sha256:451e6dbcf3a1558ce4d9da234d3b076716f799a2d8e30fc422dd8a54f67010ce",
-                "sha256:473881e592a3b798d472c1ec41d6107c584dea8c826c4f1d480317aca9de259e",
-                "sha256:4754c56c57bd129e8a1617787e0c2c75714da3a13d1ba8804275861eb6c6e488",
-                "sha256:51ac668b7c080112a839264bf8dd4593fe80663fdd29777feba0ac8d55a8443c",
-                "sha256:5d533b03e753c2bb43f7833b4b415407f75d4cf73a6976e69930fd349b5c00fc",
-                "sha256:86f2aae1ffc231e3339452d12129d53da9b2c567d8e760221c109dca70347f26",
-                "sha256:88638336186dfb4b5a32b2a083584cc67575b759c027eadc333f08c48a026782",
-                "sha256:958485d37399fa99eef8cf9bd72d483dc7c3267fae83889f939b9d3f98cfead8",
-                "sha256:9c9a036eb5f3c7e21c8601f446ad32673f5abca2cd27b078f21680725a1dfbe4",
-                "sha256:a583e8c9e5265a6e33e30b2d25bffc0fc193aa60d2d6766950afe6c9150fd697",
-                "sha256:a7f4cf124f42e8186b1c89142d445fd7a70429d4b62e606ea626c27e2f93e767",
-                "sha256:d7c79919e884f2d3743bbe58a5afa4f39bc21d7d5a458c211e9cab14f8a4062a",
-                "sha256:e5cfaf510f553f696a26005b24146ae933c21123788de981f4633035b7adf30a",
-                "sha256:f000926a63e9532c117ca5887f894f2775b85655390b7f876d6ab053be2d8536"
+                "sha256:0527480f8d51a71e67120221e6e2b0560b5d317067b6f813a2f831f4ad5303cf",
+                "sha256:14e5425d566629de84a934a018b76cdf857aac9ea05b84936a88876d1e4b647a",
+                "sha256:22afc0ae9aa83c275a482f647ed0cdc1094cb0752c870f70bde583d1e7054205",
+                "sha256:3fcd049fb65ad21794dbbc253e82d580b84be8418ec0677267e6bdfe7067764b",
+                "sha256:5280adb21a6191c7407e8fd0fbfc81a667627514029e9149970377abeb33b3d8",
+                "sha256:773446b916adeebee33ffca814f7046911abe5d2ae8ee3eb4a54fa467bfb2e45",
+                "sha256:867550777ad755210fca96836c0b162f89fb012c9ef69216bcbde03bf6f61e36",
+                "sha256:94f947314aa09f27ce5c137581f6725641d03605eabc96b736d4e7ef593ed37a",
+                "sha256:a17bf4a5b2d0c8732f496195558acbd5be89c6d6072975d1e47c7c258bcd7c33",
+                "sha256:b2b3f3a8ea22dc362e4652d302cc9b503d90776db4af96b311b992f146443dac",
+                "sha256:b34e73ec318ab3b99cbbe3d6699ac8e9e335fbe89f57edb153e07a3310ba00df",
+                "sha256:cc0a377774182be83e2867f402d2a9fe624946cbe6f9c8fcb2e6c9060cd40010",
+                "sha256:cf0375abe10459e8561edf839a38e01110a03cb5dbb15a7cc6d8db74a6259da8",
+                "sha256:e7b09cbe7a71a951afd162a9889e625b501e804cfee27e02fa1dd573125438b2",
+                "sha256:e85141345f397b05ee19b81f954b791d44c383e01125279a44fc1b5673f7dade",
+                "sha256:eab4dc471af92555b231411a72ca16968b521a579ffaa36e0cec496712afee41"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.2.1.1"
+            "version": "==2022.3.1.0"
         },
         "robotpy-halsim-gui": {
             "hashes": [
-                "sha256:017b5ec92398424c155423203cc56152b3289916250bb99f8d48462b0f599c5c",
-                "sha256:06c184b3a97a64c3c6ced72ff402bb14f68273fc651d4224076fa0a06940a4c7",
-                "sha256:103c34909fc0a0d94181a455fef8d8bfbdb103d54647974e42829b6d85331bd2",
-                "sha256:22c16736fcbf77d9edb7d2c5ba3df407f46f6e169838310d94616527e5ad1c48",
-                "sha256:2ff995559341f28292a5c031ea56c25d6359ef3b4e4c1075c3177b11557e35bd",
-                "sha256:35f0bab5c9a3ddd76fee4ed9b9d2ee3c5fd85c1cfa8908b992ac87f20fb0f165",
-                "sha256:4015a4e0cda6bb2e13d6b5370b65f600bd08711f2dee8a291e26bcdabd4f2f51",
-                "sha256:49af93fb80db49a29c7bf48a0d0cfa568397e5a137d3bc8682688b960bd9e312",
-                "sha256:55fd5baa4cdded4230cc02896e0c138a43ca22006e9592727162f63b0c25e5ff",
-                "sha256:729415089745399f043be085af61f2b79bdfcac62e6e94fe379eb4e3fc11ebdb",
-                "sha256:b4a38f093dd3e5c1baef14d56b08ad65f79246f009460fc4f3d978e1b71cb2e9",
-                "sha256:d0974232b7ceb83ea2951e497cd89cb589830234716a99f85fc91aed57f225c9",
-                "sha256:d74a71afc55791adeb66f74ee53cc1ae07c50f56ece1496b3bd4252477a79a1b",
-                "sha256:ece4a1ce1f2853e5dbc06328dbc91b41e95c8da1c6d2873e79f721d5f7605c9c",
-                "sha256:f0e312a89f7fd8a112011f1983c55c8c08ee591c9d89e6d9bb4a4896317e9efd",
-                "sha256:f3ceb8c9142fb4eb02dbf066b9426f75fdfae88153cefbdb346da444b6810704"
+                "sha256:0660d459142e1a2626b433a4c887d3692fd8866f78742d70ed7374c591dd71bd",
+                "sha256:0ae6fe4bb13b3362690cbaeac5f78111b1bb71afcb910d5df61b0e52969bed70",
+                "sha256:2e42d75c9445ea5ee7e88ccc060a97fd3f06be8d566bfc898241eff659fd938a",
+                "sha256:2e9cb300a029d732a7cdabd030809dfeb0820c5e88c32df4a057fea342bd8526",
+                "sha256:308e1cc328b482c65a1505c36bdfd8a389fc6b8074db7784e65c33343d1637a4",
+                "sha256:320b759e7a697f4062041404c445e7cf27203733854e6e38f694fbfd0fee1104",
+                "sha256:3c1ef960f07ea5a59f9ee96b9e88107796d02678d923c97f4f8a654fa2988af5",
+                "sha256:54eb8c27013204b5d9a779a49bc02a52292390a7746f21c31f217ab277381640",
+                "sha256:66d314c958d753da32ef0c4438d92be2840e843c10cbaa12d3282c5dac0d7056",
+                "sha256:7dd3f473424747fb84dc3292cbc15ee2c007ebc5c3bbca2cdb0beee0e4898c1e",
+                "sha256:9aad421d468e8812410fd7ebce1578eb0edf05fabef0b7b7ecdd5cac188f9131",
+                "sha256:d0d982935cbbf78ba2216948dcd2d6a7221d18bc2e877b4b9e3f69e8fbe232d6",
+                "sha256:d80f1c81ec15b9bc9ad970d9c3c47ea4d5c16d6fc67924d7f346204007132fc0",
+                "sha256:eef9c30882cca5904122db894709e6536ba49f5a0d44a32a95331957bdc9604e",
+                "sha256:f249a3e8a6bf62c2d501c35011bd6d72bcf6b103b016b353651519dae272fe9a",
+                "sha256:f2edeca4903361f4f39b679a4a4511350864227de8cde3f9f3feafaa29194ac2"
             ],
             "index": "pypi",
-            "version": "==2022.2.1.0"
+            "version": "==2022.3.1.0"
         },
         "robotpy-installer": {
             "hashes": [
-                "sha256:4f126a85712637a83c301f9a8bcdf81c07d82900bd8551bf613f1e46a28e7cae",
-                "sha256:f23164d33412d40856c946788897fa3e769ce46a671c777fa579ac97ebea7e4e"
+                "sha256:01e5ecd5f83b7ad27f761e508d1807995398d908f1117c5ff8843d58ac50d2fc",
+                "sha256:267e83e99c2884808c7f115355c627cce5cc5edb341070fb8824d8ca5b8bc300"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.0.2"
+            "version": "==2022.1.0"
         },
         "robotpy-navx": {
             "hashes": [
@@ -406,55 +403,55 @@
         },
         "robotpy-wpilib-utilities": {
             "hashes": [
-                "sha256:234ce31b7b73a14c52e4458499fd6f3f34c8990cd6b051d92e596176e18aa09d",
-                "sha256:ba571ef35dbd6c85471d966d5185a6ab56159ca2199d330161af5eb749634622"
+                "sha256:24e3a4cc5164be69466b62e6d7804e562936bcd24d3a306964bbfb2a9e7c6326",
+                "sha256:85ed855dc145e08b84373c7a62a4be09ece74358c3f10ae80c17a029b1d5d185"
             ],
             "index": "pypi",
-            "version": "==2022.0.1"
+            "version": "==2022.0.2"
         },
         "robotpy-wpimath": {
             "hashes": [
-                "sha256:179024d59e0f15013544939cab219adf6b40f14981bf3dbe7a03afc72e0978b1",
-                "sha256:1b9acca01fb54c3918647db6b571eb9dc02f5a69dde37861470fa8f8f1d46f3c",
-                "sha256:20b1b43867cb448192cc78043a7844346f2aeb980b2f5c89d53069e279d0298b",
-                "sha256:3abacb2824631b31fd146feac486c29f42f94245ca1406bc207ed991cf098b61",
-                "sha256:85f47db09158bcffa7e8661bfff72c793e3a37f3ca5ed549cf343003ce7939e0",
-                "sha256:91fcdb081fe07ae27d0c0ad48ce8de5d5ae39a7f46ff34d48302f1c5ef176f48",
-                "sha256:996ef73bcd577efe4aae1ad472b8f7bb74b538c67559f22bed280432cf5dd1fd",
-                "sha256:a9a9a37a9e9d583f59b61fd2c9c2a7c5cadd251c32a6cb5164e8713f9ce67235",
-                "sha256:c077010392ef5275b04d8d61b00bcd9e640a6325672f7a12832baaffd447cb57",
-                "sha256:c41960a6179c92797adb0e2cd3711a052f932f78d4620138a85a9aeebdb4aeed",
-                "sha256:ca4884e16af7c32419296b8f70eb0c7a790a79a0eb133c4b050e3ca4b0f34fca",
-                "sha256:dbdc3730c13da5af45407a78b1e14f24e6c615b7508882d62f2980adf938b197",
-                "sha256:dcc35105ec0714fbad518daf6ecd6df9648e73a448c796395593ac871f69459e",
-                "sha256:dd2f682d2ab419204a19603711002a12855085cff1f217f5cbae99b171c07bfd",
-                "sha256:f955aa757221f1346ce89cb30070825058fc533c3cf27c1c7273501d38aac0e0",
-                "sha256:fecc0420e8ed106f7f9b41f437ca8de4e34fccfa9e5f61291cbded062205353f"
+                "sha256:32649f733c22ea6556b21492b569565bce6bffe7381b7bd959facdf4dbcb56d9",
+                "sha256:4ac629d815b2957fc531eff99f893ebcddf2829e96d9be3c60dbd68cc742d90d",
+                "sha256:5425c415e32d34e4ac51fb49337925a8720107636068d227b2941a3c09462e0b",
+                "sha256:6b888a6b2036510254d4d788be4ab514f29b340a5d09d7660aab3fe2e3fd581f",
+                "sha256:7b0a195a4a2b420e09cd353ef35caa0de73f7f639f217556509492a26428cde1",
+                "sha256:8b9eb0af8bd24542784ef2ccc7d144d3e64209717c365ad57be5a126362b39d7",
+                "sha256:8da9ebd59962e1fa5389a83369c69f69c12b42836be747d59e9ffe9e90aee19c",
+                "sha256:92474bb14c9dfbdb618d6b688edbdb209eecc83a75a552ca1ec724b60ef5fd6f",
+                "sha256:a90a9d29ef418db62a7d1b223ccea506f22e4da7d24d0ec3af0e79eff0f8a73f",
+                "sha256:aa30481e1f6259f909eb841e8e26e8fd7bd9d5574ec7712abb15519fd5b3ed8c",
+                "sha256:b3c7b0cd1c71526ffdf10224fc2be6d5d1f8cc56cb9a9eaf2dffda119142d01b",
+                "sha256:b585079b8d0e1c8697373ae46210874e0abc47974b08cef810a4c9c68e6007f4",
+                "sha256:c00ab6101fe10c2d9259f98c54514da9a614317f3f87b23d3146835cbdea80a4",
+                "sha256:df99c589931cb5e3cf7ff4cd37e68672bae72e0f8674fac332e4041775187af9",
+                "sha256:f34528dafd7b9b241fecb994fe6d6ade54919b9328ee80cb904cee32abd7920f",
+                "sha256:ffd6b0cbf597ffa6b129607cd64b29978ef2ed2e3e1b82142adbf4611aca4ef0"
             ],
             "index": "pypi",
-            "version": "==2022.2.1.4"
+            "version": "==2022.3.1.0"
         },
         "robotpy-wpiutil": {
             "hashes": [
-                "sha256:069c9961e31096664fe94b6cf06ea411e3603b60ad928c579a333e285ea4224c",
-                "sha256:09522990a8dff31b58e94a80f58cfa1ff9d08666a3ad78e94bd5f83fbfa950c5",
-                "sha256:2330182dc02522aefb99187fa9f32bfd1f4ba400e2b13a07bb815df778e3dda5",
-                "sha256:33a059e4aff5df26a0d2398503a37d79f7c3351c47c27f992e0a86513d555277",
-                "sha256:34bb224350d2877ddbb276c6476473bc1b0b5e31230b278cf402f233fdc2b70e",
-                "sha256:43be786d63acc3b48a9343915e3a0bded7c7783f3a4089628f79dc03af3f4054",
-                "sha256:4e3c5b122d7f378b4e7d2ce4da884bd284908d9eb04dee643dc4850d28afc1ff",
-                "sha256:607b6f20150b1ca10e79d2a40a645a1a891506bf949ac4f498848ba5272167e5",
-                "sha256:7fd8405eb2f508f5ef1445f8fb6b965a5eb16a127ebeda4860ad7b78b04efd4c",
-                "sha256:87ee0d13ecd0f4bcd0ffe8df3b2c2c3ee1cc1a934a841f4be55786e84fe34605",
-                "sha256:93dbec3dd43d87f6a9140987d3e1b2d848056c5843d2560ea942bb7ae0356a3a",
-                "sha256:a2c6ea7fe74132d90283f4c1ebfd704464d0b7b0f4a350b24918519352225900",
-                "sha256:aae54411b219a0ca05cba3f69e29b31f26a09b604730a5bb85e04390c4162e05",
-                "sha256:c124efe0da65e5eeed2b3bb316465ab8151655431242b27ab03fbda91a22de09",
-                "sha256:c1f39cee6c9b48f08e793e66664512f07a0f56800a97ef23da3355e02b90c8ea",
-                "sha256:f7686a234e9e557eb5164298e861faeabc573a7b1119683af8cd2defb6efb629"
+                "sha256:1e6981e8d13240c1b172b1f05911c6ac1dede11418442893a6cba749fb14cb84",
+                "sha256:21ba1c62e7911d474ac164c08ca59726fc775bad329ea4531c63447f7e0e126d",
+                "sha256:2420e8a3a38d98ab37399c0a2e35fb9a0237397a0be61648f63e6c920a003a53",
+                "sha256:33d4b3cb0e06c2381d4c71229fe3aba389ef7fbcb1dfc0f0dd391c04ae682219",
+                "sha256:3ffabe2929578dadb618d71716b371ec51597f9517dbeae6a62fb7bcd4a6bedd",
+                "sha256:67436601c3152d77b4dd5f37652ceb770a0ce379878d57883ed6a6d362c46cb9",
+                "sha256:6fdf2c04f4c6d73af2bed0aa92900075abdb47b3d69ea728121b2ccf6e12a724",
+                "sha256:7daf6c1548e0e1be21db6aeda5e778e62ac222ecb0549d0a38703f45d5f9b995",
+                "sha256:810d2d86845bbb0c62de99842ec740c4881c2485a5a4430ac1406d07cb93d60a",
+                "sha256:876ff358bba25b95c8ca675afc911ae9fe5cfb7a00fd9ffc9449e31f932911f1",
+                "sha256:a7b4804a271114774cba86fd7fd9abaf48249fd80f9832a0abdde3bd27de7804",
+                "sha256:c3d66aa6a18aeec2ceccf116b47b023047721bbd7006f3f252251a631b609fd0",
+                "sha256:cea68e5270dc0b009f5d555f0cefce34d5cfc420b1aa482c8a8de8013658f718",
+                "sha256:dbe39aa30a2cd2d8d5c8153cf4d842ab4a473fa2c325a9298d052d11b9b37758",
+                "sha256:e2197460b3082551cfe3947252178b148242ed9d514109f31be4607fea19b05c",
+                "sha256:fdb971c1202323e8861b58904ed5e53866db16cb71568199f4903f037688a1fe"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.2.1.1"
+            "version": "==2022.3.1.1"
         },
         "six": {
             "hashes": [
@@ -464,35 +461,35 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
-        "toml": {
+        "tomli": {
             "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+                "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224",
+                "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
         },
         "wpilib": {
             "hashes": [
-                "sha256:2383d91fe74ef38f2331b98592ee116574c0aa7d045736ddcf7fc0462255de11",
-                "sha256:2ea14d1565238638140ea82b26ffecb9f79d7743f5c2464d7b1a91f9540ae00f",
-                "sha256:426e8cf60e969b989449f4e1119a30c330757af2310a2589ceee5a7f15e41ee8",
-                "sha256:47f4eb775d367b9bd296d6dd13a7dca92ce962d3459bec1861b3d60edceef461",
-                "sha256:573e7133112e313f3b2feed2901fca9ecf2a558fa447e6c8e1780853144a16c0",
-                "sha256:6d816e5449ed0a86943dec95c7f66e1ea8a5656ea2f4ddf07d7ccacc087be3fc",
-                "sha256:72871b0acf3b20ff58f37a88f047623de7faf4ed1d5da9db6bf47cee4140213b",
-                "sha256:83ea292d9e67bd4e2e288302159f347949f375f5c70c6ec4eda634353a52b3a0",
-                "sha256:8e1afce9477ebec8ba87fed171b4f78b25515bb4d05d1b1328a03092758d7619",
-                "sha256:994695107bf9c08e5443a3691324773bdf86b998a2200db831e5af5bc76abf74",
-                "sha256:a6ac6b69abbf2b9a57172bfcbe081dd80cc34d97f546e4c230f3f16db7df8ff1",
-                "sha256:c18ba2c1e333cbc611d86efb3acdefc4a7bebce07480789baf59c7bf98947eba",
-                "sha256:cb0d1f5cfa9ef149f5e367a76e7910e5124514f17fed21f01964b5ea6c410d91",
-                "sha256:d1b063ba885af20ef51e97c731fb15ab9d0e3478c6eb9f1c81c7ce5535d2d1b6",
-                "sha256:ee67497f8830b95baf024af543d0088d499b2b8e9b7cfd0e841b066d7905dddb",
-                "sha256:f855c75f6943d816da622958f2471915cbb453e13d5468945c742c13ba1d323c"
+                "sha256:0157d096f9651b493514e775c05b191374116e9ea86376ffcad16e739873bc38",
+                "sha256:0bdb986653eb80d2cd327295b6323eef46ccae3e78ad00101e13e9de0bdde524",
+                "sha256:19dc29e6d26a3940496d9d1338ecd213b783836bc6cde9f3f9d0f32a3e74198c",
+                "sha256:2198b26be581851d30409e6e4fa6d818710e8aa2b85ab9d2252b2f5917becf85",
+                "sha256:68ddcf1a9828ac2b8ca198483d6f5b9f12aa8048936a48752821ff74e487c96e",
+                "sha256:7b1b01305989774fb8889efe5cb92691ab5035d3998fc8298f1faf90af02a24f",
+                "sha256:7f16b9f27c85a249c7671199278314ba29984c3a02cad5883915a8b3ea2beeb5",
+                "sha256:870db04fe311e9c85fea254fa9676f2093136b1379fa7245ac4dce5b327d6276",
+                "sha256:91dfd61eebb6483b8041fec834bf38455974c6473e2c3465f76a4a7b98779886",
+                "sha256:95e036de19fca61152b57ff4bf5bb43973b820e661a984f351fff65bc263c329",
+                "sha256:9a79a8b44178797dc5d3849b03578c1b1bf6cc07127cd0150214b9a045f49642",
+                "sha256:9aaf4ff7714f54ca77596e64f1fe896068620cd15f86ac4a86a9fd048eefe241",
+                "sha256:a6717e001af810e1752490153f4322855ba0072cd656fa25d44ac80d16817e0e",
+                "sha256:e5dc6ad18ca1334c17be0bb01037e6ecb52216ca7f1cbcc22c9b2b69b159d901",
+                "sha256:f55f2e4ba6ad6c5b9a627cbd573d43baa34add4f40333154fe4e9389b0466cda",
+                "sha256:f9d0cbaa73cb19961e5906903126048e8b3970ac06794e4eb576b92cc4f76f19"
             ],
             "index": "pypi",
-            "version": "==2022.2.1.5"
+            "version": "==2022.3.1.1"
         }
     },
     "develop": {
@@ -506,11 +503,11 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:2b9c56faa067d660f0802679689f825bf142eec8261ab9e2e6ea916b1d8278a1",
-                "sha256:fa9f845b06199ea87e68c6da04a609ff46e381b5d542351184790d54eaca144c"
+                "sha256:46cbee9d7aed822149af75ec63d5f86cd1042df69b2e8eae17b26a56a4dda781",
+                "sha256:886342c291e3e592f26889f25b33aac78c6af62c736451f7cdad0a06ffa27325"
             ],
             "index": "pypi",
-            "version": "==6.36.0"
+            "version": "==6.36.1"
         },
         "iniconfig": {
             "hashes": [
@@ -553,11 +550,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
-                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
+                "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9",
+                "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==6.2.5"
+            "version": "==7.0.0"
         },
         "sortedcontainers": {
             "hashes": [
@@ -566,13 +563,13 @@
             ],
             "version": "==2.4.0"
         },
-        "toml": {
+        "tomli": {
             "hashes": [
-                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+                "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224",
+                "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.10.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
         }
     }
 }

--- a/requirements-sim.txt
+++ b/requirements-sim.txt
@@ -1,3 +1,3 @@
 pyfrc ~= 2022.0.2
-robotpy-halsim-gui ~= 2022.2.1
+robotpy-halsim-gui ~= 2022.3.1
 -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy ~= 1.22.1
-robotpy-ctre ~= 2022.0.5
-robotpy-navx ~= 2022.0.0
-robotpy-rev ~= 2022.0.0
+robotpy-ctre ~= 2022.1.0
+robotpy-navx ~= 2022.0.1
+robotpy-rev ~= 2022.0.1
 robotpy-wpilib-utilities ~= 2022.0.1
-robotpy-wpimath ~= 2022.2.1
-wpilib ~= 2022.2.1
+robotpy-wpimath ~= 2022.3.1
+wpilib ~= 2022.3.1


### PR DESCRIPTION
Requires roboRIO v4 image, and new image requires these updates.