### PR TITLE
chassis: Reduce CAN status 1 frame rates

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -72,6 +72,10 @@ class SwerveModule:
         self.drive.config_kI(0, 0, 10)
         self.drive.config_kD(0, 0, 10)
 
+        # Reduce CAN status frame rates
+        steer.setStatusFramePeriod(ctre.StatusFrameEnhanced.Status_1_General, 250, 10)
+        drive.setStatusFramePeriod(ctre.StatusFrameEnhanced.Status_1_General, 250, 10)
+
         self.target_angle = 0
 
         self.last_speed = 0


### PR DESCRIPTION
Per https://docs.ctre-phoenix.com/en/stable/ch18_CommonAPI.html#motor-controllers these frames do not include any data we use. The SDS example code also reduces the rate of these.