### PR TITLE
Bump wpimath to 2022.3.1.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ robotpy-ctre = "~=2022.1.0"
 robotpy-navx = "~=2022.0.1"
 robotpy-rev = "~=2022.0.1"
 robotpy-wpilib-utilities = "~=2022.0.1"
-robotpy-wpimath = "~=2022.3.1"
+robotpy-wpimath = "~=2022.3.1.1"
 wpilib = "~=2022.3.1"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d9046446e6252d56c656876bc764a986842c4365b63b6e557802b2f298ef8649"
+            "sha256": "ba871736be42d9ae183350b5cd323c1f08e9afb405592ace84a68141c9a13947"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -97,11 +97,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
-                "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
+                "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1",
+                "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.0.3"
+            "version": "==8.0.4"
         },
         "cryptography": {
             "hashes": [
@@ -277,11 +277,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9",
-                "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"
+                "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
+                "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==7.0.0"
+            "version": "==7.0.1"
         },
         "robotpy-ctre": {
             "hashes": [
@@ -351,11 +351,11 @@
         },
         "robotpy-installer": {
             "hashes": [
-                "sha256:01e5ecd5f83b7ad27f761e508d1807995398d908f1117c5ff8843d58ac50d2fc",
-                "sha256:267e83e99c2884808c7f115355c627cce5cc5edb341070fb8824d8ca5b8bc300"
+                "sha256:0b8bcc47c29242afd972fa5312dedfe8c4a8a09d99c743a19ae85f0b986724a3",
+                "sha256:dd64c7e1e6fb54c83be275a2913b4a411855e79a0dfd32bcdc8e05c7ece63857"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.1.0"
+            "version": "==2022.1.1"
         },
         "robotpy-navx": {
             "hashes": [
@@ -411,47 +411,47 @@
         },
         "robotpy-wpimath": {
             "hashes": [
-                "sha256:32649f733c22ea6556b21492b569565bce6bffe7381b7bd959facdf4dbcb56d9",
-                "sha256:4ac629d815b2957fc531eff99f893ebcddf2829e96d9be3c60dbd68cc742d90d",
-                "sha256:5425c415e32d34e4ac51fb49337925a8720107636068d227b2941a3c09462e0b",
-                "sha256:6b888a6b2036510254d4d788be4ab514f29b340a5d09d7660aab3fe2e3fd581f",
-                "sha256:7b0a195a4a2b420e09cd353ef35caa0de73f7f639f217556509492a26428cde1",
-                "sha256:8b9eb0af8bd24542784ef2ccc7d144d3e64209717c365ad57be5a126362b39d7",
-                "sha256:8da9ebd59962e1fa5389a83369c69f69c12b42836be747d59e9ffe9e90aee19c",
-                "sha256:92474bb14c9dfbdb618d6b688edbdb209eecc83a75a552ca1ec724b60ef5fd6f",
-                "sha256:a90a9d29ef418db62a7d1b223ccea506f22e4da7d24d0ec3af0e79eff0f8a73f",
-                "sha256:aa30481e1f6259f909eb841e8e26e8fd7bd9d5574ec7712abb15519fd5b3ed8c",
-                "sha256:b3c7b0cd1c71526ffdf10224fc2be6d5d1f8cc56cb9a9eaf2dffda119142d01b",
-                "sha256:b585079b8d0e1c8697373ae46210874e0abc47974b08cef810a4c9c68e6007f4",
-                "sha256:c00ab6101fe10c2d9259f98c54514da9a614317f3f87b23d3146835cbdea80a4",
-                "sha256:df99c589931cb5e3cf7ff4cd37e68672bae72e0f8674fac332e4041775187af9",
-                "sha256:f34528dafd7b9b241fecb994fe6d6ade54919b9328ee80cb904cee32abd7920f",
-                "sha256:ffd6b0cbf597ffa6b129607cd64b29978ef2ed2e3e1b82142adbf4611aca4ef0"
+                "sha256:0425bcf3ef719dfc05d9d395b46e40e8507f2bcfd7b827eae19c4a2a925b53f9",
+                "sha256:0ae23dae473e9d6615c288d339255ec6da17985f68bef710d989743171484866",
+                "sha256:1245a851308343ed4670f8580bee4629e762532f3dc99bd24ecd8dfb06a5ef22",
+                "sha256:381ece13fc009faaef54b2044e33ce221f5227c3d4e3f94c52c65e44a2381b95",
+                "sha256:3d8cff331783104bccf6419b3931712f3bbad9cb780c79304b4ba2e7720cf316",
+                "sha256:45c8d04df0b9fcc02d92a199fd5c2a0800689267cf5c1fedb73120d44f026e0a",
+                "sha256:45cb1eb8ea3e34d804247bd6d33d31256ac14a5ead952b5ca2f9f49cd397cdcd",
+                "sha256:530a161615b534cab286e3849fab1925e3772919cb2d34e5de16d51d6f3441f1",
+                "sha256:70187cc5fff3b994b1ce40282e3cabd29d6fdf8b888465e3c165bd230c40ca7f",
+                "sha256:80fe5258fb5cc6037818f6226c34c8eea3dc60cd7ba356704db798a25d6557f4",
+                "sha256:b2480e0ab4c4d92dda971e4b0b5dc4cb9d0037f7ed64f05847d64c63833e2783",
+                "sha256:bf57f87aa43c438041d523254b6581465db722d8a9b0335470c0c3eda4116073",
+                "sha256:ca18db0cf23f49d1d4218ad4017bb521699bd318ae9961b3071ba153738b81cd",
+                "sha256:d4fbebbbee7234b3eb980d91ff8278d98ccad408f45472585dfdbe3b839d4e74",
+                "sha256:e3c75a01bc98cca39ecc1f4bbe358e39891bba0502e3398689bcda8ab6a1a3d3",
+                "sha256:f141bf3bfeb74b570d4d6051d72e2907aba6e8bbaf6f84de8aa1d0e77846c91d"
             ],
             "index": "pypi",
-            "version": "==2022.3.1.0"
+            "version": "==2022.3.1.1"
         },
         "robotpy-wpiutil": {
             "hashes": [
-                "sha256:1e6981e8d13240c1b172b1f05911c6ac1dede11418442893a6cba749fb14cb84",
-                "sha256:21ba1c62e7911d474ac164c08ca59726fc775bad329ea4531c63447f7e0e126d",
-                "sha256:2420e8a3a38d98ab37399c0a2e35fb9a0237397a0be61648f63e6c920a003a53",
-                "sha256:33d4b3cb0e06c2381d4c71229fe3aba389ef7fbcb1dfc0f0dd391c04ae682219",
-                "sha256:3ffabe2929578dadb618d71716b371ec51597f9517dbeae6a62fb7bcd4a6bedd",
-                "sha256:67436601c3152d77b4dd5f37652ceb770a0ce379878d57883ed6a6d362c46cb9",
-                "sha256:6fdf2c04f4c6d73af2bed0aa92900075abdb47b3d69ea728121b2ccf6e12a724",
-                "sha256:7daf6c1548e0e1be21db6aeda5e778e62ac222ecb0549d0a38703f45d5f9b995",
-                "sha256:810d2d86845bbb0c62de99842ec740c4881c2485a5a4430ac1406d07cb93d60a",
-                "sha256:876ff358bba25b95c8ca675afc911ae9fe5cfb7a00fd9ffc9449e31f932911f1",
-                "sha256:a7b4804a271114774cba86fd7fd9abaf48249fd80f9832a0abdde3bd27de7804",
-                "sha256:c3d66aa6a18aeec2ceccf116b47b023047721bbd7006f3f252251a631b609fd0",
-                "sha256:cea68e5270dc0b009f5d555f0cefce34d5cfc420b1aa482c8a8de8013658f718",
-                "sha256:dbe39aa30a2cd2d8d5c8153cf4d842ab4a473fa2c325a9298d052d11b9b37758",
-                "sha256:e2197460b3082551cfe3947252178b148242ed9d514109f31be4607fea19b05c",
-                "sha256:fdb971c1202323e8861b58904ed5e53866db16cb71568199f4903f037688a1fe"
+                "sha256:006a803e4014c83f50290339f25f3013dbc6739d5ef2709ea488fbdcc3990477",
+                "sha256:0c2f9bc54b4f20005a83998b4c7784f557758c9ea193bcf5f730f4253a5fd968",
+                "sha256:0d37ab7ff1441ccf6ec3873de134d52df0d5851d0681834f51cf5dd2e8c1062b",
+                "sha256:1451205568fc64823009eae64e94fa4c0363be7fa664cc650c6fc82b0bd471d8",
+                "sha256:150ecab69df8963f938470bdd6c421790aff09e7f61418ff9555c031f7868500",
+                "sha256:44e3abfbbf306cb2ce2b50c28750fd2b947071974ded8b49ba432b3aa905cbcf",
+                "sha256:487ae2313abfd2c4c422a04eb200baa2f2dbed17e5fcd86921772bdb07953dac",
+                "sha256:5a9b53c34c99aee2faa3d19b35f36474e6ec3de923ee57b304d68549aea1d2ab",
+                "sha256:7a0403ae56b28e25227121cda60140f59cc59bca8b16152dd6060751bc6f9314",
+                "sha256:87fcfe7ecb300d57bfffb825668f9e77134843673f1ac7e251cf8e1adc165020",
+                "sha256:8c6cfe73ce06dcc1d09ee55e5b71819500237fdfeae7526106572e287f9b2601",
+                "sha256:e74b4bffdf46692b274faa5c804592f4aeee1688356a37a173ca4f5d9638ced0",
+                "sha256:f03000e63ed4b36322fa1c265b7e03bd98452dda04dd2a2bdc8b716da975227a",
+                "sha256:f6e796e9183592aa8635a404e78a385cd9c61595d49e3ca7c3d689e97a932565",
+                "sha256:f8d4ffe3495ab48fee495d6ca3686521325278cad4b5b43cf561ca0205122f66",
+                "sha256:fd002c5305683d52ec9fd61473de4f540b4db02c86095be027d6bc74294795c8"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.3.1.1"
+            "version": "==2022.3.1.3"
         },
         "six": {
             "hashes": [
@@ -463,11 +463,11 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224",
-                "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "wpilib": {
             "hashes": [
@@ -503,11 +503,11 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:46cbee9d7aed822149af75ec63d5f86cd1042df69b2e8eae17b26a56a4dda781",
-                "sha256:886342c291e3e592f26889f25b33aac78c6af62c736451f7cdad0a06ffa27325"
+                "sha256:0f407e8e87644e0c6bd2dad6c2df02892172b923065de9d302ea6ce002e6f345",
+                "sha256:f4fd3c11d997aea3675d67f3613bccbbb3ef897a96968ec483d472f5d8aa410d"
             ],
             "index": "pypi",
-            "version": "==6.36.1"
+            "version": "==6.37.0"
         },
         "iniconfig": {
             "hashes": [
@@ -550,11 +550,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9",
-                "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"
+                "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
+                "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==7.0.0"
+            "version": "==7.0.1"
         },
         "sortedcontainers": {
             "hashes": [
@@ -565,11 +565,11 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224",
-                "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         }
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ robotpy-ctre ~= 2022.1.0
 robotpy-navx ~= 2022.0.1
 robotpy-rev ~= 2022.0.1
 robotpy-wpilib-utilities ~= 2022.0.1
-robotpy-wpimath ~= 2022.3.1
+robotpy-wpimath ~= 2022.3.1.1
 wpilib ~= 2022.3.1


### PR DESCRIPTION
Fixes the `Out of memory` error on Linux when calling `repr` on a `TrapezoidProfile.State`, such as when RobotPy prints the locals when an exception occurs.

https://github.com/robotpy/robotpy-wpimath/commit/4b528a194d7b568fcb36220013a1f8a6202bdc5d