### PR TITLE
Add VSCode launch and tasks configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,45 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "RobotPy: Simulate",
+            "type": "python",
+            "request": "launch",
+            "module": "robot",
+            "args": [
+                "sim"
+            ]
+        },
+        {
+            "name": "RobotPy: Test",
+            "type": "python",
+            "request": "launch",
+            "module": "robot",
+            "args": [
+                "test"
+            ]
+        },
+        {
+            "name": "Python: pytest",
+            "type": "python",
+            "request": "launch",
+            "module": "pytest"
+        },
+        {
+            "name": "Python: Attach to roboRIO",
+            "type": "python",
+            "request": "attach",
+            "port": 5678,
+            "host": "10.47.74.2",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceFolder}",
+                    "remoteRoot": "."
+                }
+            ]
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,51 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "deploy with netconsole",
+            "type": "process",
+            "group": "build",
+            "command": "${command:python.interpreterPath}",
+            "args": [
+                "robot.py",
+                "deploy",
+                "--nc"
+            ]
+        },
+        {
+            "label": "deploy",
+            "type": "process",
+            "group":{
+                "kind": "build",
+                "isDefault": true
+            },
+            "command": "${command:python.interpreterPath}",
+            "args": [
+                "robot.py",
+                "deploy"
+            ]
+        },
+        {
+            "label": "pytest",
+            "type": "process",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "command": "${command:python.interpreterPath}",
+            "args": ["-m", "pytest"]
+        },
+        {
+            "label": "test",
+            "type": "process",
+            "group": "test",
+            "command": "${command:python.interpreterPath}",
+            "args": [
+                "robot.py",
+                "test"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Allow for running the simulator and deploying to the robot with single keyboard shortcuts.

This is largely copypasta from last year, with the following changes:

- Add configs to run pytest directly (will be removed when pyfrc tests are re-enabled)
- Make `deploy` the default build task
- Update tasks command for compatibility with newer Python VSCode extension