### PR TITLE
Reduce CAN status rates on shooter and steer encoders

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -76,6 +76,9 @@ class SwerveModule:
         # Reduce CAN status frame rates
         steer.setStatusFramePeriod(ctre.StatusFrameEnhanced.Status_1_General, 250, 10)
         drive.setStatusFramePeriod(ctre.StatusFrameEnhanced.Status_1_General, 250, 10)
+        encoder.talon.setStatusFramePeriod(
+            ctre.StatusFrameEnhanced.Status_1_General, 250, 10
+        )
 
     def get_angle(self) -> float:
         """Gets steer angle from absolute encoder"""

--- a/components/shooter.py
+++ b/components/shooter.py
@@ -58,6 +58,9 @@ class Shooter:
             motor.configSelectedFeedbackSensor(
                 ctre.FeedbackDevice.IntegratedSensor, 0, 10
             )
+            motor.setStatusFramePeriod(
+                ctre.StatusFrameEnhanced.Status_1_General, 250, 10
+            )
 
     def execute(self):
         self.right_motor.set(


### PR DESCRIPTION
We're still saturating the CAN bus apparently.

See #37