### PR TITLE
Fix 'wants to fire' flag resetting

### DIFF
--- a/controllers/shooter.py
+++ b/controllers/shooter.py
@@ -2,7 +2,14 @@ from components.indexer import Indexer
 import math
 from components.shooter import Shooter
 from components.turret import Turret
-from magicbot import StateMachine, tunable, default_state, timed_state, feedback
+from magicbot import (
+    StateMachine,
+    tunable,
+    default_state,
+    timed_state,
+    feedback,
+    will_reset_to,
+)
 from components.chassis import Chassis
 from numpy import interp
 
@@ -28,7 +35,7 @@ class ShooterController(StateMachine):
     MAX_SPEED = 0.1
     MAX_ROTATION = 0.1
 
-    _wants_to_fire = False
+    _wants_to_fire = will_reset_to(False)
 
     @default_state
     def tracking(self) -> None:
@@ -59,9 +66,6 @@ class ShooterController(StateMachine):
             and self.chassis.rotation_velocity < self.MAX_ROTATION
         ):
             self.next_state("firing")
-
-        # Reset each loop so that the call has to be made each control loop
-        self._wants_to_fire = False
 
     @timed_state(duration=0.5, first=True, next_state="tracking", must_finish=True)
     def firing(self) -> None:

--- a/robot.py
+++ b/robot.py
@@ -134,7 +134,7 @@ class MyRobot(magicbot.MagicRobot):
         else:
             self.chassis.drive_local(joystick_x, joystick_y, joystick_z)
 
-        if self.joystick.getTriggerPressed():
+        if self.joystick.getTrigger():
             self.shooter_control.fire()
 
         if self.joystick.getRawButtonPressed(2):


### PR DESCRIPTION
- The driver should be able to continuously ask the controller to fire until it fires
- Avoid the possible case of immediately attempting to take a second shot after we have fired, despite nobody currently commanding it to