### PR TITLE
turret: Fix throwing away angle wraparound

### DIFF
--- a/components/turret.py
+++ b/components/turret.py
@@ -4,7 +4,6 @@ import ctre
 import magicbot
 import math
 from wpilib import DutyCycleEncoder, Timer
-from utilities.functions import constrain_angle
 
 
 class Turret:

--- a/components/turret.py
+++ b/components/turret.py
@@ -81,7 +81,20 @@ class Turret:
             )
             self.has_synced = True
 
+    @classmethod
+    def wrap_allowable_angle(cls, theta: float) -> float:
+        """
+        Constrain a given angle to be within allowable angles for the turret.
+        This allows for some overlap around the turret's wraparound.
+        """
+        while theta > cls.MAX_ROTATION:
+            theta -= math.tau
+        while theta < -cls.MAX_ROTATION:
+            theta += math.tau
+        return theta
+
     def execute(self) -> None:
+        self.target = self.wrap_allowable_angle(self.target)
         # constrain in a way that allows a bit of overlap
         while self.target > self.MAX_ROTATION:
             self.target -= math.tau
@@ -114,7 +127,8 @@ class Turret:
 
     @magicbot.feedback
     def absolute_encoder_reading(self) -> float:
-        return constrain_angle(self.absolute_encoder.getDistance() + self.abs_offset)
+        angle = self.absolute_encoder.getDistance() + self.abs_offset
+        return self.wrap_allowable_angle(angle)
 
     def get_angle_at(self, t: float) -> float:
         loops_ago = int((Timer.getFPGATimestamp() - t) / self.control_loop_wait_time)


### PR DESCRIPTION
We attempt to resynchronise the turret encoder every time the robot is disabled or enabled. However, we were previously throwing away any rollover from the absolute encoder every time we did this.

This preserves any rollover from the absolute encoder tracked by the roboRIO, whilst still ensuring it is still within the physically possible angles of the turret.