### PR TITLE
Fix usage of IMU yaw

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -290,10 +290,6 @@ class Chassis:
         self.pose_history.appendleft(self.estimator.getEstimatedPosition())
         self.field_obj.setPose(goal_to_field(self.pose_history[0]))
 
-    @magicbot.feedback
-    def get_imu_rotation(self):
-        return self.imu.getRotation2d().radians()
-
     def sync_all(self):
         for m in self.modules:
             m.sync_steer_encoders()

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -249,7 +249,7 @@ class Chassis:
 
     def drive_field(self, x, y, z):
         """Field oriented drive commands"""
-        rotation = self.imu.getRotation2d()
+        rotation = self.get_rotation()
         self.chassis_speeds = ChassisSpeeds.fromFieldRelativeSpeeds(x, y, z, rotation)
 
     def drive_local(self, x, y, z):
@@ -311,6 +311,14 @@ class Chassis:
         self.estimator.resetPosition(
             Pose2d(cur_pose.translation(), Rotation2d(0)), self.imu.getRotation2d()
         )
+
+    def get_pose(self) -> Pose2d:
+        """Get the current location of the robot relative to the goal."""
+        return self.estimator.getEstimatedPosition()
+
+    def get_rotation(self) -> Rotation2d:
+        """Get the current heading of the robot."""
+        return self.get_pose().rotation()
 
     def get_pose_at(self, t: float) -> Pose2d:
         """Gets where the robot was at t"""


### PR DESCRIPTION
The field oriented drive code assumed that the IMU matches our coordinate system. However, this is not true as our starting poses do not face forwards.

This fixes all usages of the IMU yaw to instead read the rotation from the estimated pose, which accounts for the offset between the robot heading in the coordinate system and the yaw from the IMU.