### PR TITLE
Fix LEDs not pulsing on auto shoot

### DIFF
--- a/controllers/leds.py
+++ b/controllers/leds.py
@@ -36,3 +36,6 @@ class LedController:
         #     self.status_lights.solid(LedColours.PINK)
         else:
             self.status_lights.solid(LedColours.GREEN)
+
+        if self.shooter_control.auto_shoot:
+            self.status_lights.pulse()

--- a/robot.py
+++ b/robot.py
@@ -151,11 +151,9 @@ class MyRobot(magicbot.MagicRobot):
 
         if self.joystick.getRawButtonPressed(11):
             self.shooter_control.auto_shoot = True
-            self.status_lights.pulse()
 
         if self.joystick.getRawButtonPressed(12):
             self.shooter_control.auto_shoot = False
-            self.status_lights.stop_pulse()
 
         # reset heading to intake facing directly downfield
         if self.joystick.getRawButtonPressed(9):


### PR DESCRIPTION
The request to pulse from `teleopPeriodic` was being overwritten by the `LedController`.