### PR TITLE
Fix swerve angle calculations and clean up

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -111,25 +111,14 @@ class SwerveModule:
         target_displacement = constrain_angle(
             desired_state.angle.radians() - current_angle
         )
-        flipped_target_displacement = constrain_angle(
-            desired_state.angle.radians() - math.pi - current_angle
-        )
-        if abs(target_displacement) < abs(flipped_target_displacement):
-            target_angle = target_displacement + current_angle
-            # rescale the speed target based on how close we are to being correctly aligned
-            target_speed = desired_state.speed * math.cos(target_displacement) ** 2
-            speed_volt = self.drive_ff.calculate(target_speed)
-        else:
-            target_angle = flipped_target_displacement + current_angle
-            # rescale the speed target based on how close we are to being correctly aligned
-            target_speed = (
-                -desired_state.speed * math.cos(flipped_target_displacement) ** 2
-            )
-            speed_volt = self.drive_ff.calculate(target_speed)
-
+        target_angle = target_displacement + current_angle
         self.steer.set(
             ctre.ControlMode.Position, target_angle * self.STEER_RAD_TO_SENSOR
         )
+
+        # rescale the speed target based on how close we are to being correctly aligned
+        target_speed = desired_state.speed * math.cos(target_displacement) ** 2
+        speed_volt = self.drive_ff.calculate(target_speed)
         self.drive.set(
             ctre.ControlMode.Velocity,
             target_speed * self.METRES_TO_DRIVE_UNITS / 10,


### PR DESCRIPTION
**Problem**: The `SwerveModule.set` method attempted to account for the wraparound of the module by getting the current angle of the module and calculating the delta between the commanded angle and current angle. However, this was always reading from the absolute encoder rather than the motor sensor.

Since swapping out our heavyweight solution with the CANCoders, I believe the absolute encoder has been giving readings within [0,τ], due to specifically reading the absolute angle. This wouldn't have been the case with the previous solution.

**Solution**: This renames the get angle methods to be explicit about the _type_ of angle it's reading, fixes the code to only ever read the absolute encoder when synchronising the encoders, and cleans up the constants for clarity.

#124 has been reverted in this PR. This PR addresses the root cause of the behaviour we would've seen, and there is already an `optimize` call before we reach the `set` method, so the calculations added should (now) be redundant.

(For obvious reasons, this PR should be reviewed commit by commit.)