### PR TITLE
Use wpilib.DataLogManager for detailed logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,9 +50,8 @@ dmypy.json
 ### WPILib ###
 networktables.ini
 imgui.ini
+simgui*.json
+*.wpilog
 
 ### Project-specific ###
 gitid
-simgui-ds.json
-simgui-window.json
-simgui.json

--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ robotpy-navx = "~=2022.0.1"
 robotpy-rev = "~=2022.0.1"
 robotpy-wpilib-utilities = "~=2022.0.3"
 robotpy-wpimath = "~=2022.4.1"
-wpilib = "~=2022.4.1.4"
+wpilib = "~=2022.4.1.5"
 robotpy-wpiutil = "~=2022.4.1.1"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "48bc0bbba36b27b98e415e3951612296adfdc1b419a1b7eaf5bffcceac075425"
+            "sha256": "14a97692c0696f17a5618195f7f3aa68b5954ed622a70f430bcceac8e12a6a8d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -172,10 +172,10 @@
         },
         "paramiko": {
             "hashes": [
-                "sha256:abf71533ea9332079db7cbcc039066c3d7575eed2df10766fa03496c3bf78cf1",
-                "sha256:ff47cc35dd4c4af507d2bdc9d7def9f7fa89977212b4f926e14ac486e930f03a"
+                "sha256:ac6593479f2b47a9422eca076b22cff9f795495e6733a64723efc75dd8c92101",
+                "sha256:ddb1977853aef82804b35d72a0e597b244fa326c404c350bd00c5b01dbfee71a"
             ],
-            "version": "==2.10.2"
+            "version": "==2.10.3"
         },
         "pint": {
             "hashes": [
@@ -280,11 +280,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:b555252a95bbb2a37a97b5ac2eb050c436f7989993565f5e0c9128fcaacadd0e",
-                "sha256:f1089d218cfcc63a212c42896f1b7fbf096874d045e1988186861a1a87d27b47"
+                "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63",
+                "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.1.0"
+            "version": "==7.1.1"
         },
         "pytest-reraise": {
             "hashes": [
@@ -482,25 +482,25 @@
         },
         "wpilib": {
             "hashes": [
-                "sha256:0290134f41565c477762284a72383259fc8f6656bae72deed3856203896fc405",
-                "sha256:0d3d3356ae3295fcd089bb4e99e6085eca0c363da43d62e759a7ffdd6fdb5b32",
-                "sha256:12ff918d838defd95e57467398b72a6eb560889d85cdf61ba45f25a37aa71e2c",
-                "sha256:1fd276274da605451946219df08a9800dff302a0d35eaefa1fc1755897164099",
-                "sha256:2f3bc9d832561242d3351c137f7a860b9ce3ba46c01f62d2c4d63dd9a74ae885",
-                "sha256:642d5388309dbe0034279bc5bea6f38a7e9a16ac6952aaa835f72d567419c670",
-                "sha256:69bbeca5d47800f98aabdd31270f79d5620e9d732484cd7b3fdea7114c56e2b9",
-                "sha256:72b439d73dfafe8424ea03d08530ec6f7b061d35f9d219c8c4ce5df0f33d66d3",
-                "sha256:7892b862a3d98b73686e0f2b21a6a88ea8929c77caf0ee74f233913ade927e9e",
-                "sha256:7b7e3f64fcd2ff89ca615f75700e9cc0e690643ffbb5d2a98a0cadc0e8e9fe5a",
-                "sha256:81d8541d3ac1c8a5a6af2623e0b78a52e82c553beb96964b1dc4f20f80a35e9a",
-                "sha256:83af14aa039efd00ac0d3a39d56658ca26f215b808d7df31c9df252f8e2d24a4",
-                "sha256:898a40df840be10624d80c23d6a290d31f5087a9d17fe22bba96e0c46374eb58",
-                "sha256:93cd3b42384259105c1d1635ed062260d39fecc49c9363952c722f7d495cacaf",
-                "sha256:cd2026f8e86984c8c418142902ea5c8fe9976b3e7799d217eb6cdc4acaccc442",
-                "sha256:e5b0ef86c3f52f3d4330b05a83d98eae07e799942fff6c65957d4f5eedadc46b"
+                "sha256:042ff3c2eeae85fb4dc78464c14a35fd8c91beb646d2df0a9f18dd8209b16a81",
+                "sha256:0dae9b2357697a2d008481ef50efedcf726100e0842fbc99774deb2708f6b4d6",
+                "sha256:23ed1d47ee4a92b5a233c1ffea9fca57e254ca1401c97e46169e8cecd4bfacd4",
+                "sha256:243edf478432bf5fa154e2068881addbaa6bd3724bf9ae7fb54fc941b7561a69",
+                "sha256:3f416e198761908cf15f7c5e88592a819df76c1de7f6a68af975dad26cbdde94",
+                "sha256:47cf08364a36b4c7290d623b3b5119353634bb497a6b9865e8d7de2b70b23ebc",
+                "sha256:53ff4848aef8c6cf3928835110b0eba22a272c9961ed2dcf2414d2753c5c6f56",
+                "sha256:68d16a3f48e8f6289a9f6f4e8887ed92a2c2028be09dc6523a80380d52991e49",
+                "sha256:81fa5f484613e5ac3aa87d02ea24c9718927a9095f35bb0e8a9f2f70389f38ae",
+                "sha256:9e5ac74d4fe3c3b712d6f1a0f0e0cc0134a7423de39b66df1ac5826d4bf4589f",
+                "sha256:9e8d60d1c5a72a639dc3c830f1be04cc5829c7a7537b3af13116ae0f81aec26b",
+                "sha256:a7e49005bfc4f9069b67406b358a155052450225b0a93cf4652715467f5a2521",
+                "sha256:bc361019903892cd0dd126844be14db5e31ba9b365533dab43dce05abfcfeaec",
+                "sha256:c2e3c937211a92afbe543e10ee1ea6489428493c9f411b051136e9ab534447e6",
+                "sha256:c46b5c02a1df65fca71ddd3b0c6b83a3d8c7d07aecd082f0dc86cb2eb55cb561",
+                "sha256:f5e447359e4d2e8796f468809af72fecddee056d05ff43b9c9d1ad7b2ad4214d"
             ],
             "index": "pypi",
-            "version": "==2022.4.1.4"
+            "version": "==2022.4.1.5"
         }
     },
     "develop": {
@@ -514,11 +514,11 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:92f1c58e994e109897fd9b3c6d44eb3bd45ed95bf3c079c35f36fa0801fc5f31",
-                "sha256:f496dd053fb951b6da9611481fb4e54eeab1d37b594da5efe869083fad3ae621"
+                "sha256:41503e20a246ab4522d78f2df8afc40fd7349eeaf0fe07cdc233069c671e6e35",
+                "sha256:f60b1dfaa8c2175c40513449f9c49b7543d50e66e16a5e22cf5fca460e864037"
             ],
             "index": "pypi",
-            "version": "==6.39.3"
+            "version": "==6.39.4"
         },
         "iniconfig": {
             "hashes": [
@@ -561,11 +561,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:b555252a95bbb2a37a97b5ac2eb050c436f7989993565f5e0c9128fcaacadd0e",
-                "sha256:f1089d218cfcc63a212c42896f1b7fbf096874d045e1988186861a1a87d27b47"
+                "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63",
+                "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.1.0"
+            "version": "==7.1.1"
         },
         "sortedcontainers": {
             "hashes": [

--- a/controllers/indexer.py
+++ b/controllers/indexer.py
@@ -6,6 +6,7 @@ from magicbot import (
     timed_state,
     tunable,
 )
+import wpiutil.log
 
 from controllers.shooter import ShooterController
 
@@ -13,9 +14,13 @@ from controllers.shooter import ShooterController
 class IndexerController(StateMachine):
     indexer: Indexer
     shooter_control: ShooterController
+    data_log: wpiutil.log.DataLog
 
     wants_to_intake = tunable(False)
     ignore_colour = tunable(False)
+
+    def setup(self) -> None:
+        self.log_colour = wpiutil.log.StringLogEntry(self.data_log, "/my/colour")
 
     def stop(self) -> None:
         self.next_state("stopping")
@@ -56,6 +61,7 @@ class IndexerController(StateMachine):
         if state_tm > 0.3:
             if not colour.is_valid() and state_tm < 0.5:
                 return
+            self.log_colour.append(colour.name)
             if colour.is_opposition() and not self.ignore_colour:
                 self.next_state("clearing")
                 """

--- a/controllers/shooter.py
+++ b/controllers/shooter.py
@@ -1,5 +1,4 @@
 import math
-import time
 from components.indexer import Indexer
 from components.shooter import Shooter
 from components.turret import Turret

--- a/controllers/shooter.py
+++ b/controllers/shooter.py
@@ -17,6 +17,7 @@ from components.chassis import Chassis
 from wpimath.geometry import Pose2d, Translation2d, Rotation2d
 import wpilib
 import navx
+import wpiutil.log
 from utilities.trajectory_generator import goal_to_field
 from utilities.functions import constrain_angle, interpolate
 
@@ -60,6 +61,8 @@ class ShooterController(StateMachine):
 
     _wants_to_fire = will_reset_to(False)
     field: wpilib.Field2d
+    data_log: wpiutil.log.DataLog
+
     # dont want to lead shots in auto beacuse we are shoot on the move
     # and the it causes weird behavoir with wrapping
     lead_shots = tunable(False)
@@ -69,17 +72,9 @@ class ShooterController(StateMachine):
     def __init__(self) -> None:
         self.flywheels_running = True
         self.track_target = True
-        self.log_file = open(
-            "./1.log"
-            if wpilib.RobotBase.isSimulation()
-            else "/home/lvuser/py/shooting_positions.log",
-            "a",
-        )
-
-    def on_enable(self):
-        print(time.ctime(), file=self.log_file, flush=True)
 
     def setup(self) -> None:
+        self.log_pose = wpiutil.log.DoubleArrayLogEntry(self.data_log, "/my/pose")
         self.field_effective_goal = self.field.getObject("effective_goal")
         self.field_effective_goal.setPose(goal_to_field(Pose2d(0, 0, 0)))
 
@@ -158,11 +153,8 @@ class ShooterController(StateMachine):
     @timed_state(duration=0.5, first=True, next_state="tracking", must_finish=True)
     def firing(self, initial_call) -> None:
         if initial_call:
-            print(
-                f"{wpilib.DriverStation.getMatchTime()} {self.chassis.get_pose()}",
-                file=self.log_file,
-                flush=True,
-            )
+            pose = self.chassis.get_pose()
+            self.log_pose.append([pose.X(), pose.Y(), pose.rotation().radians()])
         if self.flywheels_running:
             if self.interpolation_override:
                 self.shooter.motor_speed = self.flywheel_speed

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ robotpy-rev ~= 2022.0.1
 robotpy-wpilib-utilities ~= 2022.0.3
 robotpy-wpimath ~= 2022.4.1
 robotpy-wpiutil ~= 2022.4.1.1
-wpilib ~= 2022.4.1.4
+wpilib ~= 2022.4.1.5

--- a/robot.py
+++ b/robot.py
@@ -44,6 +44,7 @@ class MyRobot(magicbot.MagicRobot):
 
     def createObjects(self):
         self.logger.info("pyrapidreact %s", GIT_INFO)
+        self.data_log = wpilib.DataLogManager.getLog()
 
         self.imu = navx.AHRS.create_spi()
 


### PR DESCRIPTION
Docs:

- https://docs.wpilib.org/en/stable/docs/software/telemetry/datalog.html
- https://robotpy.readthedocs.io/projects/wpilib/en/stable/wpilib/DataLogManager.html#wpilib.DataLogManager

DataLogTool is part of the WPILib 2022.4.1 installer, or available from https://frcmaven.wpi.edu/artifactory/wpilib-mvn-release-local/edu/wpi/first/tools/DataLogTool/

`wpilib` package update is required due to broken bindings in earlier versions of RobotPy.