### PR TITLE
Use WPIMath trajectory generators for auto

### DIFF
--- a/autonomous/autonomous.py
+++ b/autonomous/autonomous.py
@@ -215,9 +215,7 @@ class AutoBase(AutonomousStateMachine):
             current_translation = self.chassis.get_pose().translation()
         first_translation = self.current_movement.trajectory.initialPose().translation()
         # Don't adjust the rotation, just the translation
-        self.current_trajectory = self.movements[
-            self.current_movement_idx
-        ].trajectory.transformBy(
+        self.current_trajectory = self.current_movement.trajectory.transformBy(
             Transform2d(current_translation - first_translation, Rotation2d(0.0))
         )
 

--- a/autonomous/autonomous.py
+++ b/autonomous/autonomous.py
@@ -80,9 +80,8 @@ class AutoBase(AutonomousStateMachine):
         self.auto_trajectory = self.field.getObject("auto_trajectory")
         self.field_auto_target_pose.setPose(Pose2d(0, 0, 0))
 
-        max_speed = (
-            self.chassis.max_attainable_wheel_speed * 0.75
-        )  # Leave some headroom over the max unloaded speed
+        # Leave some headroom over the max unloaded speed
+        max_speed = self.chassis.max_attainable_wheel_speed * 0.75
         self.trajectory_config = TrajectoryConfig(
             maxVelocity=max_speed, maxAcceleration=max_speed / 0.4
         )  # Acceleration expressed as max_speed / t where t is time taken to reach max speed

--- a/autonomous/autonomous.py
+++ b/autonomous/autonomous.py
@@ -79,10 +79,16 @@ class AutoBase(AutonomousStateMachine):
         self.field_auto_target_pose = self.field.getObject("auto_target_pose")
         self.auto_trajectory = self.field.getObject("auto_trajectory")
         self.field_auto_target_pose.setPose(Pose2d(0, 0, 0))
-        self.trajectory_config = TrajectoryConfig(maxVelocity=3.5, maxAcceleration=9.0)
+
+        max_speed = (
+            self.chassis.max_attainable_wheel_speed * 0.75
+        )  # Leave some headroom over the max unloaded speed
+        self.trajectory_config = TrajectoryConfig(
+            maxVelocity=max_speed, maxAcceleration=max_speed / 0.4
+        )  # Acceleration expressed as max_speed / t where t is time taken to reach max speed
         self.trajectory_config.addConstraint(
             constraint.SwerveDrive4KinematicsConstraint(
-                self.chassis.kinematics, maxSpeed=4.0
+                self.chassis.kinematics, maxSpeed=max_speed
             )
         )
         # add additional constraints here if required

--- a/autonomous/autonomous.py
+++ b/autonomous/autonomous.py
@@ -121,7 +121,7 @@ class AutoBase(AutonomousStateMachine):
         target_state = self.current_trajectory.sample(traj_time)
         target_heading = self.current_movement.chassis_heading
 
-        current_pose = self.chassis.estimator.getEstimatedPosition()
+        current_pose = self.chassis.get_pose()
 
         if traj_time > self.current_trajectory.totalTime() and (
             self.drive_controller.atReference() or wpilib.RobotBase.isSimulation()

--- a/autonomous/autonomous.py
+++ b/autonomous/autonomous.py
@@ -286,6 +286,66 @@ class TestAuto(AutoBase):
         ]
 
 
+class ExerciseAuto(AutoBase):
+    MODE_NAME = "exercise"
+    # Run a test routine in confined spaces that has the same total distance and changes of direction as the 5 ball
+
+    def setup(self) -> None:
+        super().setup()
+        self.movements = [
+            Movement(
+                WaypointType.PICKUP,
+                TrajectoryGenerator.generateTrajectory(
+                    start=Pose2d(-1, 0, Rotation2d.fromDegrees(180)),
+                    end=Pose2d(-3, 0, Rotation2d.fromDegrees(180)),
+                    interiorWaypoints=[],
+                    config=self.trajectory_config,
+                ),
+                Rotation2d.fromDegrees(180),
+            ),
+            Movement(
+                WaypointType.PICKUP,
+                TrajectoryGenerator.generateTrajectory(
+                    start=Pose2d(-3, 0, Rotation2d.fromDegrees(0)),
+                    end=Pose2d(-1, 2, Rotation2d.fromDegrees(90)),
+                    interiorWaypoints=[],
+                    config=self.trajectory_config,
+                ),
+                Rotation2d.fromDegrees(90),
+            ),
+            Movement(
+                WaypointType.PICKUP,
+                TrajectoryGenerator.generateTrajectory(
+                    start=Pose2d(-1, 2, Rotation2d.fromDegrees(-90)),
+                    end=Pose2d(-1, -2, Rotation2d.fromDegrees(-90)),
+                    interiorWaypoints=[],
+                    config=self.trajectory_config,
+                ),
+                Rotation2d.fromDegrees(-90),
+            ),
+            Movement(
+                WaypointType.PICKUP,
+                TrajectoryGenerator.generateTrajectory(
+                    start=Pose2d(-1, -2, Rotation2d.fromDegrees(90)),
+                    end=Pose2d(-3, 2, Rotation2d.fromDegrees(180)),
+                    interiorWaypoints=[],
+                    config=self.trajectory_config,
+                ),
+                Rotation2d.fromDegrees(135),
+            ),
+            Movement(
+                WaypointType.PICKUP,
+                TrajectoryGenerator.generateTrajectory(
+                    start=Pose2d(-3, 2, Rotation2d.fromDegrees(-90)),
+                    end=Pose2d(-1, 0, Rotation2d.fromDegrees(0)),
+                    interiorWaypoints=[],
+                    config=self.trajectory_config,
+                ),
+                Rotation2d.fromDegrees(180),
+            ),
+        ]
+
+
 class FiveBall(AutoBase):
     """Auto starting middle of right tarmac, picking up balls 3, 2 and both at terminal"""
 

--- a/autonomous/autonomous.py
+++ b/autonomous/autonomous.py
@@ -134,7 +134,6 @@ class AutoBase(AutonomousStateMachine):
             else:
                 self.move_next_waypoint(tm)
 
-        # currentPose rotation and linearVelocityRef is only used for feedforward
         self.chassis_speeds = self.drive_controller.calculate(
             currentPose=current_pose,
             desiredState=target_state,

--- a/autonomous/autonomous.py
+++ b/autonomous/autonomous.py
@@ -47,7 +47,7 @@ class AutoBase(AutonomousStateMachine):
 
     logger: logging.Logger
 
-    drive_rotation_constraints = trajectory.TrapezoidProfileRadians.Constraints(8, 8)
+    drive_rotation_constraints = trajectory.TrapezoidProfileRadians.Constraints(8, 24)
 
     ALLOWED_TRANS_ERROR = 0.1
     ALLOWED_ROT_ERROR = math.radians(10)
@@ -56,12 +56,12 @@ class AutoBase(AutonomousStateMachine):
         super().__init__()
 
         rotation_controller = controller.ProfiledPIDControllerRadians(
-            4, 0, 0, self.drive_rotation_constraints
+            4, 0, 0.3, self.drive_rotation_constraints
         )
         rotation_controller.enableContinuousInput(-math.pi, math.pi)
         self.drive_controller = controller.HolonomicDriveController(
-            controller.PIDController(2, 0, 0.2),
-            controller.PIDController(2, 0, 0.2),
+            controller.PIDController(2, 0, 0.4),
+            controller.PIDController(2, 0, 0.4),
             rotation_controller,
         )
         self.drive_controller.setTolerance(
@@ -81,9 +81,9 @@ class AutoBase(AutonomousStateMachine):
         self.field_auto_target_pose.setPose(Pose2d(0, 0, 0))
 
         # Leave some headroom over the max unloaded speed
-        max_speed = self.chassis.max_attainable_wheel_speed * 0.75
+        max_speed = self.chassis.max_attainable_wheel_speed * 0.3
         self.trajectory_config = TrajectoryConfig(
-            maxVelocity=max_speed, maxAcceleration=max_speed / 0.4
+            maxVelocity=max_speed, maxAcceleration=max_speed / 0.5
         )  # Acceleration expressed as max_speed / t where t is time taken to reach max speed
         self.trajectory_config.addConstraint(
             constraint.SwerveDrive4KinematicsConstraint(
@@ -291,7 +291,7 @@ class ExerciseAuto(AutoBase):
             Movement(
                 WaypointType.PICKUP,
                 TrajectoryGenerator.generateTrajectory(
-                    start=Pose2d(-1, 0, Rotation2d.fromDegrees(180)),
+                    start=Pose2d(-1.5, 0, Rotation2d.fromDegrees(180)),
                     end=Pose2d(-3, 0, Rotation2d.fromDegrees(180)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
@@ -302,7 +302,7 @@ class ExerciseAuto(AutoBase):
                 WaypointType.PICKUP,
                 TrajectoryGenerator.generateTrajectory(
                     start=Pose2d(-3, 0, Rotation2d.fromDegrees(0)),
-                    end=Pose2d(-1, 2, Rotation2d.fromDegrees(90)),
+                    end=Pose2d(-1.5, 2, Rotation2d.fromDegrees(90)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
@@ -311,8 +311,8 @@ class ExerciseAuto(AutoBase):
             Movement(
                 WaypointType.PICKUP,
                 TrajectoryGenerator.generateTrajectory(
-                    start=Pose2d(-1, 2, Rotation2d.fromDegrees(-90)),
-                    end=Pose2d(-1, -2, Rotation2d.fromDegrees(-90)),
+                    start=Pose2d(-1.5, 2, Rotation2d.fromDegrees(-90)),
+                    end=Pose2d(-1.5, -2, Rotation2d.fromDegrees(-90)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
@@ -321,7 +321,7 @@ class ExerciseAuto(AutoBase):
             Movement(
                 WaypointType.PICKUP,
                 TrajectoryGenerator.generateTrajectory(
-                    start=Pose2d(-1, -2, Rotation2d.fromDegrees(90)),
+                    start=Pose2d(-1.5, -2, Rotation2d.fromDegrees(90)),
                     end=Pose2d(-3, 2, Rotation2d.fromDegrees(180)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,

--- a/autonomous/autonomous.py
+++ b/autonomous/autonomous.py
@@ -212,9 +212,7 @@ class AutoBase(AutonomousStateMachine):
                 self.current_movement.trajectory.initialPose().translation()
             )
         else:
-            current_translation = (
-                self.chassis.estimator.getEstimatedPosition().translation()
-            )
+            current_translation = self.chassis.get_pose().translation()
         first_translation = self.current_movement.trajectory.initialPose().translation()
         # Don't adjust the rotation, just the translation
         self.current_trajectory = self.movements[

--- a/autonomous/autonomous.py
+++ b/autonomous/autonomous.py
@@ -117,7 +117,7 @@ class AutoBase(AutonomousStateMachine):
             # Nicer visualisation in sim
             target_heading = target_state.pose.rotation()
         else:
-            self.current_movement.chassis_heading
+            target_heading = self.current_movement.chassis_heading
 
         current_pose = self.chassis.estimator.getEstimatedPosition()
 
@@ -238,44 +238,44 @@ class TestAuto(AutoBase):
         super().setup()
         self.movements = [
             Movement(
-                WaypointType.SIMPLE,
+                WaypointType.PICKUP,
                 TrajectoryGenerator.generateTrajectory(
                     start=Pose2d(0, 0, Rotation2d.fromDegrees(-45)),
                     end=Pose2d(2, 0, Rotation2d.fromDegrees(45)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(90),
+                Rotation2d.fromDegrees(0),
             ),
             Movement(
-                WaypointType.SIMPLE,
+                WaypointType.PICKUP,
                 TrajectoryGenerator.generateTrajectory(
                     start=Pose2d(2, 0, Rotation2d.fromDegrees(45)),
                     end=Pose2d(2, 2, Rotation2d.fromDegrees(135)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(180),
+                Rotation2d.fromDegrees(90),
             ),
             Movement(
-                WaypointType.SIMPLE,
+                WaypointType.PICKUP,
                 TrajectoryGenerator.generateTrajectory(
                     start=Pose2d(2, 2, Rotation2d.fromDegrees(135)),
                     end=Pose2d(0, 2, Rotation2d.fromDegrees(225)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(270),
+                Rotation2d.fromDegrees(180),
             ),
             Movement(
-                WaypointType.SIMPLE,
+                WaypointType.PICKUP,
                 TrajectoryGenerator.generateTrajectory(
                     start=Pose2d(0, 2, Rotation2d.fromDegrees(225)),
                     end=Pose2d(0, 0, Rotation2d.fromDegrees(315)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(0),
+                Rotation2d.fromDegrees(270),
             ),
         ]
 

--- a/autonomous/autonomous.py
+++ b/autonomous/autonomous.py
@@ -226,6 +226,7 @@ class AutoBase(AutonomousStateMachine):
 # balls positions are described in https://docs.google.com/document/d/1K2iGdIX5vyCDEaJtaLdUiC-ihC9xyGYjrKFfLbvpusI/edit
 
 # start positions
+# don't change rotations because the initial robot pose is set from them!
 right_mid_start = Pose2d(-0.630, -2.334, Rotation2d.fromDegrees(-88.5))
 left_mid_start = Pose2d(-2.156, 1.093, Rotation2d.fromDegrees(136.5))
 
@@ -244,7 +245,7 @@ class TestAuto(AutoBase):
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(0),
+                Rotation2d.fromDegrees(45),
             ),
             Movement(
                 WaypointType.PICKUP,
@@ -254,7 +255,7 @@ class TestAuto(AutoBase):
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(90),
+                Rotation2d.fromDegrees(135),
             ),
             Movement(
                 WaypointType.PICKUP,
@@ -264,7 +265,7 @@ class TestAuto(AutoBase):
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(180),
+                Rotation2d.fromDegrees(225),
             ),
             Movement(
                 WaypointType.PICKUP,
@@ -274,7 +275,7 @@ class TestAuto(AutoBase):
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(270),
+                Rotation2d.fromDegrees(315),
             ),
         ]
 
@@ -292,17 +293,17 @@ class FiveBall(AutoBase):
                 WaypointType.SHOOT,
                 TrajectoryGenerator.generateTrajectory(
                     start=right_mid_start,
-                    end=Pose2d(-0.65, -3.55, Rotation2d.fromDegrees(-80)),
+                    end=Pose2d(-0.65, -3.55, Rotation2d.fromDegrees(-90)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(-80),
+                Rotation2d.fromDegrees(-88.5),
             ),
             Movement(
                 WaypointType.SHOOT,
                 TrajectoryGenerator.generateTrajectory(
                     start=Pose2d(-0.65, -3.55, Rotation2d.fromDegrees(100)),
-                    end=Pose2d(-4.2, -2.3, Rotation2d.fromDegrees(180)),
+                    end=Pose2d(-3.4, -2.1, Rotation2d.fromDegrees(180)),
                     interiorWaypoints=[
                         Translation2d(-1.8, -2.3),
                     ],
@@ -313,22 +314,22 @@ class FiveBall(AutoBase):
             Movement(
                 WaypointType.PICKUP,
                 TrajectoryGenerator.generateTrajectory(
-                    start=Pose2d(-4.2, -2.3, Rotation2d.fromDegrees(180)),
-                    end=Pose2d(-8.0, -2.5, Rotation2d.fromDegrees(-136)),
+                    start=Pose2d(-3.4, -2.1, Rotation2d.fromDegrees(170)),
+                    end=Pose2d(-6.95, -2.8, Rotation2d.fromDegrees(-135)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(-136),
+                Rotation2d.fromDegrees(-135),
             ),
             Movement(
                 WaypointType.SHOOT,
                 TrajectoryGenerator.generateTrajectory(
-                    start=Pose2d(-8.0, -2.5, Rotation2d.fromDegrees(44)),
+                    start=Pose2d(-6.95, -2.8, Rotation2d.fromDegrees(45)),
                     end=Pose2d(-5.0, -2.0, Rotation2d.fromDegrees(0)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(-136),
+                Rotation2d.fromDegrees(-135),
             ),
         ]
 
@@ -346,7 +347,7 @@ class FourBall(AutoBase):
                 WaypointType.SHOOT,
                 TrajectoryGenerator.generateTrajectory(
                     start=left_mid_start,
-                    end=Pose2d(-3.1, 1.8, Rotation2d.fromDegrees(130)),
+                    end=Pose2d(-3.1, 1.8, Rotation2d.fromDegrees(160)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
@@ -356,7 +357,7 @@ class FourBall(AutoBase):
                 WaypointType.PICKUP,
                 TrajectoryGenerator.generateTrajectory(
                     start=Pose2d(-3.1, 1.8, Rotation2d.fromDegrees(-130)),
-                    end=Pose2d(-7.25, -2.75, Rotation2d.fromDegrees(-136)),
+                    end=Pose2d(-7.25, -2.75, Rotation2d.fromDegrees(-135)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
@@ -365,7 +366,7 @@ class FourBall(AutoBase):
             Movement(
                 WaypointType.SHOOT,
                 TrajectoryGenerator.generateTrajectory(
-                    start=Pose2d(-7.25, -2.75, Rotation2d.fromDegrees(44)),
+                    start=Pose2d(-7.25, -2.75, Rotation2d.fromDegrees(75)),
                     end=Pose2d(-5.0, 0.0, Rotation2d.fromDegrees(30)),
                     interiorWaypoints=[],
                     config=self.trajectory_config,

--- a/autonomous/autonomous.py
+++ b/autonomous/autonomous.py
@@ -309,7 +309,7 @@ class FiveBall(AutoBase):
                     ],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(-206),
+                Rotation2d.fromDegrees(180),
             ),
             Movement(
                 WaypointType.PICKUP,
@@ -361,7 +361,7 @@ class FourBall(AutoBase):
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(130),
+                Rotation2d.fromDegrees(-136),
             ),
             Movement(
                 WaypointType.SHOOT,
@@ -371,7 +371,7 @@ class FourBall(AutoBase):
                     interiorWaypoints=[],
                     config=self.trajectory_config,
                 ),
-                Rotation2d.fromDegrees(130),
+                Rotation2d.fromDegrees(-136),
             ),
         ]
 

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -74,9 +74,13 @@ class SwerveModule:
         self.drive.setInverted(drive_reversed)
         self.drive.configVoltageCompSaturation(12, timeoutMs=10)
         self.drive.enableVoltageCompensation(True)
-        self.drive_ff = SimpleMotorFeedforwardMeters(kS=0.65599, kV=2.8309, kA=0.15238)
+        self.drive_ff = SimpleMotorFeedforwardMeters(kS=0.71164, kV=2.6308, kA=0.1178)
+        self.drive.configVelocityMeasurementPeriod(
+            ctre.SensorVelocityMeasPeriod.Period_5Ms
+        )
+        self.drive.configVelocityMeasurementWindow(8)
 
-        self.drive.config_kP(0, 0.00064721, 10)
+        self.drive.config_kP(0, 0.0023546, 10)
         self.drive.config_kI(0, 0, 10)
         self.drive.config_kD(0, 0, 10)
 

--- a/components/chassis.py
+++ b/components/chassis.py
@@ -74,7 +74,7 @@ class SwerveModule:
         self.drive.setInverted(drive_reversed)
         self.drive.configVoltageCompSaturation(12, timeoutMs=10)
         self.drive.enableVoltageCompensation(True)
-        self.drive_ff = SimpleMotorFeedforwardMeters(kS=0.71164, kV=2.6308, kA=0.1178)
+        self.drive_ff = SimpleMotorFeedforwardMeters(kS=0.71164, kV=2.55, kA=0.1178)
         self.drive.configVelocityMeasurementPeriod(
             ctre.SensorVelocityMeasPeriod.Period_5Ms
         )
@@ -236,7 +236,7 @@ class Chassis:
         )
         self.control_rate = 1 / self.control_loop_wait_time
         self.field_obj = self.field.getObject("fused_pose")
-        self.set_pose(Pose2d(-0.711, -2.419, Rotation2d.fromDegrees(-88.5)))
+        self.set_pose(Pose2d(-2, 0, Rotation2d.fromDegrees(180)))
 
     def drive_field(self, vx: float, vy: float, omega: float) -> None:
         """Field oriented drive commands"""

--- a/components/vision.py
+++ b/components/vision.py
@@ -26,7 +26,7 @@ class Vision:
 
     field: wpilib.Field2d
 
-    fuse_vision_observations = tunable(True)
+    fuse_vision_observations = tunable(False)
     gate_innovation = tunable(True)
 
     def __init__(self) -> None:

--- a/robot.py
+++ b/robot.py
@@ -107,7 +107,7 @@ class MyRobot(magicbot.MagicRobot):
         self.shooter_control.lead_shots = False
         self.intake.auto_retract = False
         self.shooter_control.auto_shoot = False
-        self.vision.max_std_dev = 0.5
+        self.vision.fuse_vision_observations = False
 
     def teleopInit(self) -> None:
         self.status_lights.display_morse = False
@@ -116,6 +116,7 @@ class MyRobot(magicbot.MagicRobot):
         self.indexer_control.ignore_colour = False
         self.shooter_control.auto_shoot = False
         self.vision.max_std_dev = 0.4
+        self.vision.fuse_vision_observations = True
 
     def disabledInit(self) -> None:
         self.status_lights.choose_morse_message()

--- a/simgui.json
+++ b/simgui.json
@@ -45,6 +45,16 @@
             255.0
           ]
         },
+        "auto_trajectory": {
+          "arrows": false,
+          "color": [
+            0.0,
+            1.0,
+            1.0,
+            255.0
+          ],
+          "style": "Line"
+        },
         "bottom": 480,
         "effective_goal": {
           "arrows": false,


### PR DESCRIPTION
Needs some twiddling of waypoint heading to get it fully smooth.

Sets the desired chassis heading directly in the call to `drive_controller.calculate()` because the PID controller for yaw is profiled, therefore it does the ramping up and down for us.