### PR TITLE
robot: Run camera stream in robot process

### DIFF
--- a/robot.py
+++ b/robot.py
@@ -98,11 +98,13 @@ class MyRobot(magicbot.MagicRobot):
         self.chassis_3_encoder = ctre.CANCoder(3)
         self.chassis_4_encoder = ctre.CANCoder(4)
 
-        wpilib.CameraServer.launch()
-
-    @magicbot.feedback
-    def get_cameraserver_alive(self):
-        return wpilib.CameraServer.is_alive()
+        if self.isReal():
+            try:
+                from cscore import CameraServer  # type: ignore
+            except ImportError:
+                self.logger.exception("Could not import CameraServer")
+            else:
+                CameraServer.getInstance().startAutomaticCapture()
 
     def autonomousInit(self) -> None:
         self.shooter_control.lead_shots = False


### PR DESCRIPTION
We're sometimes getting MemoryErrors when deploying after the robot code has run for a while.

Run the camera stream in process to reduce RAM usage by about 8 MB.