### PR TITLE
leds: Fix vision status

### DIFF
--- a/controllers/leds.py
+++ b/controllers/leds.py
@@ -17,7 +17,7 @@ class LedController:
     def execute(self) -> None:
         if not self.vision.is_connected():
             self.status_lights.pulse(LedColours.PINK)
-        if not self.indexer.has_cargo_in_chimney():
+        elif not self.indexer.has_cargo_in_chimney():
             self.status_lights.solid(LedColours.ORANGE)
         elif not self.shooter_control.in_range():
             self.status_lights.solid(LedColours.BLUE)


### PR DESCRIPTION
Before a match, the robot will never be in range to shoot. Hence, if vision was not connected, the "not in range" status would previously always overwrite the "vision disconnected" status.