### PR TITLE
Reduce CAN status frames before configuration

### DIFF
--- a/components/chassis.py
+++ b/components/chassis.py
@@ -47,7 +47,15 @@ class SwerveModule:
     ):
         self.translation = Translation2d(x, y)
         self.steer = steer
-        self.steer.configFactoryDefault()
+        self.drive = drive
+
+        steer.configFactoryDefault()
+        drive.configFactoryDefault()
+
+        # Reduce CAN status frame rates before configuring
+        steer.setStatusFramePeriod(ctre.StatusFrameEnhanced.Status_1_General, 250, 10)
+        drive.setStatusFramePeriod(ctre.StatusFrameEnhanced.Status_1_General, 250, 10)
+
         self.steer.setNeutralMode(ctre.NeutralMode.Brake)
         self.steer.setInverted(steer_reversed)
 
@@ -69,8 +77,6 @@ class SwerveModule:
             timeoutMs=10,
         )
 
-        self.drive = drive
-        self.drive.configFactoryDefault()
         self.drive.setNeutralMode(ctre.NeutralMode.Brake)
         self.drive.setInverted(drive_reversed)
         self.drive.configVoltageCompSaturation(12, timeoutMs=10)
@@ -84,10 +90,6 @@ class SwerveModule:
         self.drive.config_kP(0, 0.0023546, 10)
         self.drive.config_kI(0, 0, 10)
         self.drive.config_kD(0, 0, 10)
-
-        # Reduce CAN status frame rates
-        steer.setStatusFramePeriod(ctre.StatusFrameEnhanced.Status_1_General, 250, 10)
-        drive.setStatusFramePeriod(ctre.StatusFrameEnhanced.Status_1_General, 250, 10)
 
     def get_absolute_angle(self) -> float:
         """Gets steer angle from absolute encoder"""

--- a/components/indexer.py
+++ b/components/indexer.py
@@ -50,15 +50,10 @@ class Indexer:
     has_trapped_cargo = tunable(False)
 
     def setup(self) -> None:
-        self.indexer_tunnel_motor.restoreFactoryDefaults()
-        self.indexer_tunnel_motor.setInverted(True)
-        self.indexer_tunnel_motor.setIdleMode(rev.CANSparkMax.IdleMode.kBrake)
-        self.indexer_chimney_motor.restoreFactoryDefaults()
-        self.indexer_chimney_motor.setInverted(False)
-        self.indexer_chimney_motor.setIdleMode(rev.CANSparkMax.IdleMode.kBrake)
-
-        # Reduce all CAN periodic status frame rates.
         for motor in (self.indexer_chimney_motor, self.indexer_tunnel_motor):
+            motor.restoreFactoryDefaults()
+
+            # Reduce all CAN periodic status frame rates.
             motor.setPeriodicFramePeriod(
                 rev.CANSparkMaxLowLevel.PeriodicFrame.kStatus0, 500
             )
@@ -71,6 +66,11 @@ class Indexer:
             motor.setPeriodicFramePeriod(
                 rev.CANSparkMaxLowLevel.PeriodicFrame.kStatus3, 500
             )
+
+        self.indexer_tunnel_motor.setInverted(True)
+        self.indexer_tunnel_motor.setIdleMode(rev.CANSparkMax.IdleMode.kBrake)
+        self.indexer_chimney_motor.setInverted(False)
+        self.indexer_chimney_motor.setIdleMode(rev.CANSparkMax.IdleMode.kBrake)
 
         for sendable in (
             self.lower_chimney_prox_sensor,

--- a/components/shooter.py
+++ b/components/shooter.py
@@ -29,14 +29,16 @@ class Shooter:
     turret_offset = Translation2d(-0.148, 0)  # From CAD
 
     def setup(self) -> None:
-        self.left_motor.setInverted(False)
-        self.right_motor.setInverted(True)
-
         for motor in (
             self.left_motor,
             self.right_motor,
         ):
             motor.configFactoryDefault()
+
+            motor.setStatusFramePeriod(
+                ctre.StatusFrameEnhanced.Status_1_General, 250, 10
+            )
+
             motor.setNeutralMode(ctre.NeutralMode.Coast)
 
             motor.configVoltageCompSaturation(self.COMPENSATED_VOLTAGE, timeoutMs=10)
@@ -51,12 +53,9 @@ class Shooter:
             motor.config_kP(0, self.pidP, 10)
             motor.config_kI(0, self.pidI, 10)
             motor.config_kD(0, self.pidD, 10)
-            motor.configSelectedFeedbackSensor(
-                ctre.FeedbackDevice.IntegratedSensor, 0, 10
-            )
-            motor.setStatusFramePeriod(
-                ctre.StatusFrameEnhanced.Status_1_General, 250, 10
-            )
+
+        self.left_motor.setInverted(False)
+        self.right_motor.setInverted(True)
 
     def on_disable(self) -> None:
         self._stop_motors()


### PR DESCRIPTION
The earlier we reduce CAN bus traffic, the more likely subsequent sends on the CAN bus will succeed.